### PR TITLE
add compact-box sweep acceleration for 3dgs and 2dgs

### DIFF
--- a/docs/COMPACT_BOX.md
+++ b/docs/COMPACT_BOX.md
@@ -24,6 +24,7 @@ intersection for `gsplat`.
 - `compact_box: bool = False`
 - `compact_box_mult: float = 1.0`
 - `compact_box_tau2: Optional[float] = None`
+- `compact_box_impl: Literal["rect_min", "sweep"] = "sweep"`
 
 These are passed through to `isect_tiles()`.
 
@@ -39,6 +40,11 @@ These are passed through to `isect_tiles()`.
 
 Gaussians with invalid conics (`q00 <= 0`, `q11 <= 0`, or `q00*q11-q01*q01 <= 0`)
 or non-positive `tau2_i` are hard-skipped in CB mode.
+
+`compact_box_impl` controls pruning implementation:
+
+- `rect_min`: per-tile rectangle minimum test (reference path)
+- `sweep`: slice-based span traversal (faster path)
 
 ## Tile predicate
 

--- a/docs/COMPACT_BOX.md
+++ b/docs/COMPACT_BOX.md
@@ -1,0 +1,104 @@
+# Compact Box (CB) for Tile Intersection
+
+This repository includes a FastGS-style Compact Box (CB) pruning path in tile
+intersection for `gsplat`.
+
+## What it does
+
+- CB prunes Gaussian-tile pairs in `isect_tiles` using Mahalanobis distance in
+  projected 2D space.
+- The pruning happens before sorting and rasterization, so it reduces
+  `n_isects` directly.
+- Default behavior is unchanged: CB is opt-in.
+
+## Where it is implemented
+
+- CUDA tile intersection kernel: `gsplat/cuda/csrc/isect_tiles.cu`
+- Python tile intersection wrapper: `gsplat/cuda/_wrapper.py`
+- Python rasterization API entrypoint: `gsplat/rendering.py`
+
+## API
+
+`gsplat.rendering.rasterization()` now exposes:
+
+- `compact_box: bool = False`
+- `compact_box_mult: float = 1.0`
+- `compact_box_tau2: Optional[float] = None`
+
+These are passed through to `isect_tiles()`.
+
+## Threshold behavior
+
+- If `compact_box=False`, no CB pruning is applied.
+- If `compact_box=True` and `compact_box_tau2` is provided, that value is used
+  directly as the squared Mahalanobis threshold.
+- If `compact_box=True` and `compact_box_tau2` is `None`, a provisional mapping
+  is used:
+
+  `tau2 = 9.0 * compact_box_mult^2`
+
+This mapping is intentionally simple for PoC and can be replaced later with an
+exact FastGS-equivalent formula if needed.
+
+## Tile predicate
+
+For each candidate tile from the existing radius-based coarse box, the kernel
+computes
+
+`min_{(x, y) in tile_rect} [x, y] Q [x, y]^T`
+
+where `Q` is the projected conic (`cov2d^{-1}`) and `(x, y)` is relative to the
+Gaussian center.
+
+The pair is kept iff:
+
+`min_d2 <= tau2`
+
+The rectangle uses a continuous pixel-center convention:
+
+- `x in [tile_x * tile_size + 0.5, (tile_x + 1) * tile_size - 0.5]`
+- `y in [tile_y * tile_size + 0.5, (tile_y + 1) * tile_size - 0.5]`
+
+## Quick usage
+
+```python
+from gsplat.rendering import rasterization
+
+render_colors, render_alphas, meta = rasterization(
+    means,
+    quats,
+    scales,
+    opacities,
+    colors,
+    viewmats,
+    Ks,
+    width,
+    height,
+    packed=False,
+    compact_box=True,
+    compact_box_mult=1.0,
+    # compact_box_tau2=9.0,  # optional explicit threshold
+)
+
+print(meta["tiles_per_gauss"].float().mean(), meta["isect_ids"].numel())
+```
+
+## A/B benchmark script
+
+Use `examples/benchmark_compact_box.py` to compare baseline and CB on a
+synthetic scene:
+
+```bash
+PYTHONPATH=. python examples/benchmark_compact_box.py \
+  --packed False \
+  --iters 20 \
+  --warmup 5 \
+  --compact-box-mult 1.0
+```
+
+The script reports:
+
+- `n_isects`
+- mean `tiles_per_gauss`
+- average render time
+- image difference (`max_abs`, `mean_abs`, `rmse`, `psnr`) between baseline and CB

--- a/docs/COMPACT_BOX.md
+++ b/docs/COMPACT_BOX.md
@@ -32,13 +32,13 @@ These are passed through to `isect_tiles()`.
 - If `compact_box=False`, no CB pruning is applied.
 - If `compact_box=True` and `compact_box_tau2` is provided, that value is used
   directly as the squared Mahalanobis threshold.
-- If `compact_box=True` and `compact_box_tau2` is `None`, a provisional mapping
-  is used:
+- If `compact_box=True` and `compact_box_tau2` is `None`, a FastGS-style
+  per-Gaussian threshold is used:
 
-  `tau2 = 9.0 * compact_box_mult^2`
+  `tau2_i = compact_box_mult * 2 * log(opacity_i * 255)`
 
-This mapping is intentionally simple for PoC and can be replaced later with an
-exact FastGS-equivalent formula if needed.
+Gaussians with invalid conics (`q00 <= 0`, `q11 <= 0`, or `q00*q11-q01*q01 <= 0`)
+or non-positive `tau2_i` are hard-skipped in CB mode.
 
 ## Tile predicate
 
@@ -77,7 +77,7 @@ render_colors, render_alphas, meta = rasterization(
     packed=False,
     compact_box=True,
     compact_box_mult=1.0,
-    # compact_box_tau2=9.0,  # optional explicit threshold
+    # compact_box_tau2=9.0,  # optional explicit global threshold override
 )
 
 print(meta["tiles_per_gauss"].float().mean(), meta["isect_ids"].numel())
@@ -102,3 +102,13 @@ The script reports:
 - mean `tiles_per_gauss`
 - average render time
 - image difference (`max_abs`, `mean_abs`, `rmse`, `psnr`) between baseline and CB
+
+You can also sweep compactness multipliers in one run:
+
+```bash
+PYTHONPATH=. python examples/benchmark_compact_box.py \
+  --sweep-mults 0.7 1.0 1.3
+```
+
+Note: `--sweep-mults` requires `--compact-box-tau2 None` (default), because
+explicit `tau2` override disables mult-based thresholding.

--- a/docs/COMPACT_BOX.md
+++ b/docs/COMPACT_BOX.md
@@ -118,3 +118,9 @@ PYTHONPATH=. python examples/benchmark_compact_box.py \
 
 Note: `--sweep-mults` requires `--compact-box-tau2 None` (default), because
 explicit `tau2` override disables mult-based thresholding.
+
+## 2DGS
+
+2DGS Compact Box support is documented separately in:
+
+- `docs/COMPACT_BOX_2DGS.md`

--- a/docs/COMPACT_BOX_2DGS.md
+++ b/docs/COMPACT_BOX_2DGS.md
@@ -1,0 +1,92 @@
+# Compact Box (CB) for 2DGS
+
+This note describes Compact Box tile pruning for `rasterization_2dgs()`.
+
+## What it does
+
+- CB prunes Gaussian-tile pairs in `isect_tiles` before sorting/rasterization.
+- For 2DGS, the pruning conic is derived from `ray_transforms` (homography-aware
+  geometry) instead of 3DGS `conics`.
+- Default behavior is unchanged: CB is opt-in.
+
+## API
+
+`gsplat.rendering.rasterization_2dgs()` exposes:
+
+- `compact_box: bool = False`
+- `compact_box_mult: float = 1.0`
+- `compact_box_tau2: Optional[float] = None`
+- `compact_box_impl: Literal["rect_min", "sweep"] = "sweep"`
+
+## Threshold behavior
+
+- If `compact_box=False`, no CB pruning is applied.
+- If `compact_box=True` and `compact_box_tau2` is provided, that value is used
+  directly.
+- If `compact_box=True` and `compact_box_tau2` is `None`, per-Gaussian threshold
+  is used:
+
+  `tau2_i = compact_box_mult * 2 * log(opacity_i * 255)`
+
+- If `tau2_i <= 0`, the Gaussian is skipped in CB mode.
+
+## Implementation modes
+
+- `rect_min`: per-tile rectangle minimum test (reference path)
+- `sweep`: slice/span traversal (faster path)
+
+## 2DGS-specific robustness
+
+- CB derives a 2D conic approximation from each Gaussian's `ray_transforms`.
+- If conic derivation is ill-conditioned, CB falls back to baseline coarse
+  radius-box traversal for that Gaussian (no aggressive hard skip).
+
+## Quick usage
+
+```python
+from gsplat.rendering import rasterization_2dgs
+
+render_colors, render_alphas, render_normals, surf_normals, render_distort, render_median, meta = rasterization_2dgs(
+    means,
+    quats,
+    scales,
+    opacities,
+    colors,
+    viewmats,
+    Ks,
+    width,
+    height,
+    compact_box=True,
+    compact_box_mult=1.0,
+    compact_box_impl="sweep",
+)
+
+print(meta["tiles_per_gauss"].float().mean(), meta["isect_ids"].numel())
+```
+
+## Benchmark script
+
+Use `examples/benchmark_compact_box_2dgs.py`:
+
+```bash
+PYTHONPATH=. python examples/benchmark_compact_box_2dgs.py \
+  --iters 20 \
+  --warmup 5 \
+  --compact-box-mult 1.0
+```
+
+Sweep multipliers in one run:
+
+```bash
+PYTHONPATH=. python examples/benchmark_compact_box_2dgs.py \
+  --sweep-mults 0.7 1.0 1.3
+```
+
+## Recommended profile
+
+- Default/safe profile: `compact_box=True`, `compact_box_impl="sweep"`,
+  `compact_box_mult=1.0`.
+- If you need more speed and can accept a slightly larger image delta,
+  try `compact_box_mult=0.8`.
+- If you need stricter visual parity with baseline, use `compact_box_mult=1.2`
+  or set explicit `compact_box_tau2`.

--- a/docs/COMPACT_BOX_MATH.md
+++ b/docs/COMPACT_BOX_MATH.md
@@ -1,0 +1,176 @@
+# Compact Box Math: `rect_min` vs `sweep`
+
+This note explains the math behind Compact Box (CB) tile pruning, and why
+`rect_min` and `sweep` differ in speed while staying close in behavior.
+
+---
+
+## 1) Core CB Quantity
+
+For each projected Gaussian, we work in image space with:
+
+- Center: `mu = (mu_x, mu_y)`
+- Precision (inverse covariance) matrix:
+
+  ```text
+  Q = [ q00  q01 ]
+      [ q01  q11 ]
+  ```
+
+- Local coordinates:
+
+  ```text
+  dx = x - mu_x
+  dy = y - mu_y
+  ```
+
+- Quadratic form:
+
+  ```text
+  f(x, y) = [dx dy] * Q * [dx dy]^T
+  ```
+
+Interpretation:
+
+- `f(x, y)` is the squared Mahalanobis distance under `Q`.
+- Small `f` means near the Gaussian center in anisotropic metric.
+- Large `f` means far away.
+
+CB keeps tile contributions where this distance is below threshold.
+
+---
+
+## 2) Threshold and Opacity Coupling
+
+If no explicit global override is given, threshold is per Gaussian:
+
+```text
+tau2_i = compact_box_mult * 2 * log(opacity_i * 255)
+```
+
+The keep region is:
+
+```text
+f(x, y) <= tau2_i
+```
+
+### Intuition
+
+- Higher opacity -> larger `tau2_i` -> larger ellipse -> more tiles kept.
+- Lower opacity -> smaller `tau2_i` -> tighter ellipse -> fewer tiles kept.
+- If `tau2_i <= 0`, the Gaussian contributes zero CB tiles.
+
+### Validity checks
+
+CB hard-skips a Gaussian if conic is invalid:
+
+- `q00 <= 0`, or
+- `q11 <= 0`, or
+- `q00 * q11 - q01 * q01 <= 0` (not positive-definite).
+
+---
+
+## 3) Geometric Picture
+
+The set
+
+```text
+{ (x, y) | f(x, y) <= tau2 }
+```
+
+is an ellipse in image space (possibly rotated when `q01 != 0`).
+
+Tile pruning asks: does this ellipse intersect a tile?
+
+---
+
+## 4) `rect_min` vs `sweep`: Same Ellipse, Different Intersection Operator
+
+## `rect_min` (reference path)
+
+For each candidate tile rectangle `R`, compute:
+
+```text
+min_{(x, y) in R} f(x, y)
+```
+
+Keep tile iff:
+
+```text
+min_{(x, y) in R} f(x, y) <= tau2
+```
+
+In implementation, this minimum is evaluated via finite convex candidates:
+
+- 4 corners
+- interior optimum `(0, 0)` if it lies inside the tile-local rectangle
+- edge stationary points:
+  - `y* = -q01 * x / q11` on vertical edges
+  - `x* = -q01 * y / q00` on horizontal edges
+
+Pros:
+
+- Tight per-tile test.
+
+Cons:
+
+- Expensive, because it is done tile-by-tile.
+
+---
+
+## `sweep` (fast path)
+
+Instead of per-tile optimization, it computes ellipse spans per strip:
+
+1. Build ellipse extent bounds from `Q` and `tau2`.
+2. Sweep by x-slices (or y-slices, whichever span is shorter).
+3. For each slice, solve ellipse-line intersections analytically.
+4. Convert continuous min/max span to a contiguous tile index range.
+5. Emit/count full range directly.
+
+This is a scanline/span fill of the same ellipse.
+
+Pros:
+
+- Lower overhead and better throughput.
+
+Cons:
+
+- Boundary discretization can differ slightly from exact per-tile min test.
+
+---
+
+## 5) Why Small Output Differences Can Exist
+
+Both methods target the same set `f <= tau2`, but:
+
+- `rect_min` is exact rectangle-min criterion per tile.
+- `sweep` uses slice boundary intersections plus range discretization.
+
+So a few borderline tiles may differ near ellipse boundaries.
+
+In practice this often gives negligible image deltas while improving runtime.
+
+---
+
+## 6) Practical Relationship Summary
+
+```text
+opacity up -> tau2 up -> ellipse area up -> n_isects up -> more raster work
+```
+
+```text
+Q larger in precision sense -> ellipse tighter -> n_isects down
+```
+
+```text
+compact_box_mult up -> tau2 up -> less pruning
+```
+
+---
+
+## 7) Rule of Thumb
+
+- Use `sweep` for performance runs.
+- Use `rect_min` as a reference/debug path when you want stricter per-tile
+  geometric checking.

--- a/docs/COMPACT_BOX_SWEEP_CN.md
+++ b/docs/COMPACT_BOX_SWEEP_CN.md
@@ -1,0 +1,187 @@
+# Compact Box `sweep` 路径中文说明
+
+本文用中文解释 `sweep`（快速路径）与 `rect_min`（参考路径）的数学差异，重点讲清 `sweep` 的每个步骤。
+
+---
+
+## 1. 问题定义
+
+对每个投影后的高斯，我们有：
+
+- 中心：`mu = (mu_x, mu_y)`
+- 精度矩阵（协方差逆）：
+
+  ```text
+  Q = [ q00  q01 ]
+      [ q01  q11 ]
+  ```
+
+- 局部坐标：
+
+  ```text
+  dx = x - mu_x
+  dy = y - mu_y
+  ```
+
+- 二次型：
+
+  ```text
+  f(x, y) = [dx dy] * Q * [dx dy]^T
+  ```
+
+Compact Box 的保留条件是：
+
+```text
+f(x, y) <= tau2
+```
+
+其中 `tau2` 可由不透明度推导：
+
+```text
+tau2_i = compact_box_mult * 2 * log(opacity_i * 255)
+```
+
+这定义了一个椭圆（`Q` 正定时）。目标是快速求出它覆盖了哪些 tile。
+
+---
+
+## 2. `sweep` 的核心思想
+
+`rect_min` 是逐 tile 精确判定：每个 tile 都做一次最小值优化。
+
+`sweep` 则是几何扫描：
+
+1. 先算椭圆包围范围；
+2. 选 x 或 y 方向做条带扫描；
+3. 每个条带解“直线与椭圆”的交点；
+4. 得到该条带覆盖的连续 tile 区间；
+5. 直接计数/写出整段区间。
+
+换句话说：`sweep` 是“scanline/span fill”思想，不是“逐 tile 优化”。
+
+---
+
+## 3. 步骤一：由 `Q` 与 `tau2` 得椭圆外接范围
+
+先算：
+
+```text
+det = q00 * q11 - q01 * q01
+x_ext = sqrt(tau2 * q11 / det)
+y_ext = sqrt(tau2 * q00 / det)
+```
+
+于是连续空间包围盒：
+
+```text
+x in [mu_x - x_ext, mu_x + x_ext]
+y in [mu_y - y_ext, mu_y + y_ext]
+```
+
+再转成 tile 索引范围（`floor/ceil` + clamp 到图像边界）。
+
+实现里还会与 coarse box（由半径给出的候选范围）取交，保证更稳健。
+
+---
+
+## 4. 步骤二：选择扫描方向（扫短边）
+
+计算 tile 跨度：
+
+```text
+x_span = rect_max_x - rect_min_x
+y_span = rect_max_y - rect_min_y
+```
+
+若 `y_span < x_span`，按 y 扫；否则按 x 扫。
+
+原因很直接：扫短边能减少循环次数，通常更快。
+
+---
+
+## 5. 步骤三：每个条带求椭圆交点（解析解）
+
+以下以“按 x 扫”为例（按 y 完全对称）。
+
+对每个 x-tile 条带：
+
+```text
+x0 = tx * tile_size
+x1 = x0 + tile_size
+```
+
+固定 `x`，解方程 `f(x, y) = tau2`，得到 y 方向交点：
+
+```text
+y = mu_y - (q01 * dx) / q11 +- sqrt(q11 * tau2 - det * dx^2) / q11
+```
+
+其中 `dx = x - mu_x`。
+
+实现会对 `x0`、`x1` 都算一次，形成条带在 y 方向的候选覆盖范围。
+
+另外，条带内部可能包含椭圆的局部极值点（不一定落在边界），所以还要补上极值检查，避免漏掉最大/最小 y。
+
+---
+
+## 6. 步骤四：连续范围离散化为 tile 区间
+
+若得到连续覆盖 `[v_min, v_max]`（在 y 轴上），转换为离散 tile 行：
+
+```text
+ty_min = floor(v_min / tile_size)
+ty_max = floor(v_max / tile_size) + 1
+```
+
+最后得到半开区间：
+
+```text
+ty in [ty_min, ty_max)
+```
+
+这是一段连续 tile，可一次处理，而不是逐格判定。
+
+---
+
+## 7. 步骤五：两遍一致的 count / emit
+
+`isect_tiles` 是两遍流程：
+
+- Pass 1：只计数（prefix-sum 用）
+- Pass 2：按同样逻辑写出 `(camera, tile, depth, flatten_id)`
+
+`sweep` 在两遍复用同一套条带区间逻辑，这样可保证：
+
+- 计数与实际写出严格一致
+- 不会出现偏移错位
+
+---
+
+## 8. 为什么 `sweep` 更快
+
+`rect_min` 的复杂度更接近“候选 tile 数量 * 每 tile 计算成本”。
+
+`sweep` 更像“条带数量 * 解析求交 + 连续区间写出”。
+
+当椭圆覆盖 tile 较多时，`sweep` 通常显著减少计算和分支开销。
+
+---
+
+## 9. 为什么边界可能有轻微差异
+
+与 `rect_min` 相比，`sweep` 可能在边缘 tile 上有极少差异，主要来自：
+
+1. 条带边界采样（`x0/x1` 或 `y0/y1`）
+2. `floor/ceil/+1` 离散化规则
+3. 边界 clamp（图像边界或 coarse box）
+4. 浮点误差
+
+这些差异通常只出现在椭圆边缘，画面影响很小，但性能收益明显。
+
+---
+
+## 10. 实践建议
+
+- 追求速度：优先用 `compact_box_impl="sweep"`
+- 做基线对照/调试：用 `compact_box_impl="rect_min"`
+- 若要比较质量差异，配合 benchmark 输出的 `max_abs/psnr` 观察边界影响

--- a/examples/benchmark_compact_box.py
+++ b/examples/benchmark_compact_box.py
@@ -36,6 +36,7 @@ class Config:
     packed: bool = False
     compact_box_mult: float = 1.0
     compact_box_tau2: Optional[float] = None
+    sweep_mults: Optional[list[float]] = None
     device: str = "cuda"
 
 
@@ -173,6 +174,15 @@ def format_float(x: float) -> str:
     return f"{x:.6f}"
 
 
+def print_mode(name: str, result: ModeResult, extra: str = "") -> None:
+    suffix = f" {extra}" if extra else ""
+    print(
+        f"{name}: avg_render_ms={result['avg_ms']:.3f} "
+        f"n_isects={result['n_isects']} "
+        f"tiles_per_gauss_mean={result['tiles_mean']:.4f}{suffix}"
+    )
+
+
 def main(cfg: Config) -> None:
     device = torch.device(cfg.device)
     if device.type == "cuda" and not torch.cuda.is_available():
@@ -201,9 +211,49 @@ def main(cfg: Config) -> None:
         warmup=cfg.warmup,
         iters=cfg.iters,
         compact_box=False,
-        compact_box_mult=1.0,
+        compact_box_mult=1,
         compact_box_tau2=None,
     )
+    print("\n[Baseline]")
+    print_mode("baseline", base)
+
+    if cfg.sweep_mults is not None and cfg.compact_box_tau2 is not None:
+        raise ValueError(
+            "sweep_mults and compact_box_tau2 cannot be used together. "
+            "Set compact_box_tau2=None for mult sweep."
+        )
+
+    if cfg.sweep_mults:
+        print("\n[Sweep: CompactBox mult]")
+        print(
+            "mult, avg_render_ms, n_isects, tiles_per_gauss_mean, speedup_x, n_isects_delta_pct, psnr"
+        )
+        for mult in cfg.sweep_mults:
+            cb = run_mode(
+                scene=scene,
+                width=cfg.width,
+                height=cfg.height,
+                packed=cfg.packed,
+                warmup=cfg.warmup,
+                iters=cfg.iters,
+                compact_box=True,
+                compact_box_mult=float(mult),
+                compact_box_tau2=None,
+            )
+            diff = image_diff_metrics(base["render"], cb["render"])
+            speedup = base["avg_ms"] / cb["avg_ms"] if cb["avg_ms"] > 0 else 0.0
+            isect_ratio = (
+                100.0 * (cb["n_isects"] / base["n_isects"] - 1.0)
+                if base["n_isects"] > 0
+                else 0.0
+            )
+            print(
+                f"{mult:.4f}, {cb['avg_ms']:.3f}, {cb['n_isects']}, "
+                f"{cb['tiles_mean']:.4f}, {speedup:.4f}, {isect_ratio:+.2f}, "
+                f"{format_float(diff['psnr'])}"
+            )
+        return
+
     cb = run_mode(
         scene=scene,
         width=cfg.width,
@@ -218,21 +268,13 @@ def main(cfg: Config) -> None:
 
     diff = image_diff_metrics(base["render"], cb["render"])
 
-    print("\n[Baseline]")
-    print(
-        f"avg_render_ms={base['avg_ms']:.3f} n_isects={base['n_isects']} "
-        f"tiles_per_gauss_mean={base['tiles_mean']:.4f}"
-    )
-
     print("\n[CompactBox]")
-    tau2_display = cfg.compact_box_tau2
-    if tau2_display is None:
-        tau2_display = 9.0 * cfg.compact_box_mult * cfg.compact_box_mult
-    print(
-        f"avg_render_ms={cb['avg_ms']:.3f} n_isects={cb['n_isects']} "
-        f"tiles_per_gauss_mean={cb['tiles_mean']:.4f} "
-        f"mult={cfg.compact_box_mult:.4f} tau2={tau2_display:.6f}"
+    tau_text = (
+        f"tau2_override={cfg.compact_box_tau2:.6f}"
+        if cfg.compact_box_tau2 is not None
+        else "tau2=mult*2*log(opacity*255)"
     )
+    print_mode("compact_box", cb, extra=f"mult={cfg.compact_box_mult:.4f} {tau_text}")
 
     isect_delta = cb["n_isects"] - base["n_isects"]
     isect_ratio = 0.0

--- a/examples/benchmark_compact_box.py
+++ b/examples/benchmark_compact_box.py
@@ -1,0 +1,258 @@
+"""Compact Box A/B benchmark with synthetic Gaussians.
+
+Example:
+    python examples/benchmark_compact_box.py --packed False --iters 20 --warmup 5
+"""
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, TypedDict
+
+import torch
+import torch.nn.functional as F
+import tyro
+
+from gsplat.rendering import rasterization
+
+
+class ModeResult(TypedDict):
+    render: torch.Tensor
+    meta: Dict[str, Any]
+    avg_ms: float
+    n_isects: int
+    tiles_mean: float
+
+
+@dataclass
+class Config:
+    seed: int = 42
+    gaussians: int = 120000
+    cameras: int = 2
+    width: int = 1280
+    height: int = 720
+    warmup: int = 10
+    iters: int = 50
+    packed: bool = False
+    compact_box_mult: float = 1.0
+    compact_box_tau2: Optional[float] = None
+    device: str = "cuda"
+
+
+def make_synthetic_scene(
+    device: torch.device,
+    n_gaussians: int,
+    n_cameras: int,
+    width: int,
+    height: int,
+) -> Dict[str, torch.Tensor]:
+    means = torch.empty(n_gaussians, 3, device=device)
+    means[:, 0] = torch.randn(n_gaussians, device=device) * 1.2
+    means[:, 1] = torch.randn(n_gaussians, device=device) * 0.8
+    means[:, 2] = torch.rand(n_gaussians, device=device) * 3.0 + 1.0
+
+    quats = F.normalize(torch.randn(n_gaussians, 4, device=device), dim=-1)
+    scales = torch.rand(n_gaussians, 3, device=device) * 0.08 + 0.01
+    opacities = torch.sigmoid(torch.randn(n_gaussians, device=device) * 0.5)
+    colors = torch.rand(n_gaussians, 3, device=device)
+
+    viewmats = torch.eye(4, device=device).unsqueeze(0).repeat(n_cameras, 1, 1)
+    if n_cameras > 1:
+        # Small x-axis camera shifts to create multi-view variation.
+        offsets = torch.linspace(-0.08, 0.08, steps=n_cameras, device=device)
+        viewmats[:, 0, 3] = -offsets
+
+    focal = 0.9 * float(max(width, height))
+    Ks = torch.tensor(
+        [[focal, 0.0, width / 2.0], [0.0, focal, height / 2.0], [0.0, 0.0, 1.0]],
+        device=device,
+        dtype=torch.float32,
+    ).unsqueeze(0)
+    Ks = Ks.repeat(n_cameras, 1, 1)
+
+    return {
+        "means": means,
+        "quats": quats,
+        "scales": scales,
+        "opacities": opacities,
+        "colors": colors,
+        "viewmats": viewmats,
+        "Ks": Ks,
+    }
+
+
+@torch.no_grad()
+def run_mode(
+    scene: Dict[str, torch.Tensor],
+    width: int,
+    height: int,
+    packed: bool,
+    warmup: int,
+    iters: int,
+    compact_box: bool,
+    compact_box_mult: float,
+    compact_box_tau2: Optional[float],
+) -> ModeResult:
+    last_render = None
+    last_meta = None
+
+    if scene["means"].is_cuda:
+        torch.cuda.synchronize(scene["means"].device)
+
+    raster_kwargs: Dict[str, Any] = {
+        "means": scene["means"],
+        "quats": scene["quats"],
+        "scales": scene["scales"],
+        "opacities": scene["opacities"],
+        "colors": scene["colors"],
+        "viewmats": scene["viewmats"],
+        "Ks": scene["Ks"],
+        "width": width,
+        "height": height,
+        "packed": packed,
+        "compact_box": compact_box,
+        "compact_box_mult": compact_box_mult,
+        "compact_box_tau2": compact_box_tau2,
+    }
+
+    for _ in range(warmup):
+        last_render, _, last_meta = rasterization(**raster_kwargs)
+
+    if scene["means"].is_cuda:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            last_render, _, last_meta = rasterization(**raster_kwargs)
+        end.record()
+        torch.cuda.synchronize(scene["means"].device)
+        avg_ms = start.elapsed_time(end) / float(iters)
+    else:
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            last_render, _, last_meta = rasterization(**raster_kwargs)
+        t1 = time.perf_counter()
+        avg_ms = (t1 - t0) * 1000.0 / float(iters)
+
+    assert last_render is not None and last_meta is not None
+
+    tiles_per_gauss = last_meta["tiles_per_gauss"].float()
+    n_isects = int(last_meta["isect_ids"].numel())
+    out: ModeResult = {
+        "render": last_render,
+        "meta": last_meta,
+        "avg_ms": avg_ms,
+        "n_isects": n_isects,
+        "tiles_mean": float(tiles_per_gauss.mean().item()),
+    }
+    return out
+
+
+def image_diff_metrics(a: torch.Tensor, b: torch.Tensor) -> Dict[str, float]:
+    diff = (a - b).abs()
+    max_abs = float(diff.max().item())
+    mean_abs = float(diff.mean().item())
+    mse = float(((a - b) ** 2).mean().item())
+    rmse = math.sqrt(max(mse, 0.0))
+    if mse <= 1e-20:
+        psnr = float("inf")
+    else:
+        psnr = 10.0 * math.log10(1.0 / mse)
+    return {
+        "max_abs": max_abs,
+        "mean_abs": mean_abs,
+        "mse": mse,
+        "rmse": rmse,
+        "psnr": psnr,
+    }
+
+
+def format_float(x: float) -> str:
+    if math.isinf(x):
+        return "inf"
+    return f"{x:.6f}"
+
+
+def main(cfg: Config) -> None:
+    device = torch.device(cfg.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available, but --device=cuda was requested")
+
+    torch.manual_seed(cfg.seed)
+    scene = make_synthetic_scene(
+        device=device,
+        n_gaussians=cfg.gaussians,
+        n_cameras=cfg.cameras,
+        width=cfg.width,
+        height=cfg.height,
+    )
+
+    print("=== Compact Box A/B Benchmark ===")
+    print(
+        f"device={device} gaussians={cfg.gaussians} cameras={cfg.cameras} "
+        f"resolution={cfg.width}x{cfg.height} packed={cfg.packed} tile_size=16"
+    )
+
+    base = run_mode(
+        scene=scene,
+        width=cfg.width,
+        height=cfg.height,
+        packed=cfg.packed,
+        warmup=cfg.warmup,
+        iters=cfg.iters,
+        compact_box=False,
+        compact_box_mult=1.0,
+        compact_box_tau2=None,
+    )
+    cb = run_mode(
+        scene=scene,
+        width=cfg.width,
+        height=cfg.height,
+        packed=cfg.packed,
+        warmup=cfg.warmup,
+        iters=cfg.iters,
+        compact_box=True,
+        compact_box_mult=cfg.compact_box_mult,
+        compact_box_tau2=cfg.compact_box_tau2,
+    )
+
+    diff = image_diff_metrics(base["render"], cb["render"])
+
+    print("\n[Baseline]")
+    print(
+        f"avg_render_ms={base['avg_ms']:.3f} n_isects={base['n_isects']} "
+        f"tiles_per_gauss_mean={base['tiles_mean']:.4f}"
+    )
+
+    print("\n[CompactBox]")
+    tau2_display = cfg.compact_box_tau2
+    if tau2_display is None:
+        tau2_display = 9.0 * cfg.compact_box_mult * cfg.compact_box_mult
+    print(
+        f"avg_render_ms={cb['avg_ms']:.3f} n_isects={cb['n_isects']} "
+        f"tiles_per_gauss_mean={cb['tiles_mean']:.4f} "
+        f"mult={cfg.compact_box_mult:.4f} tau2={tau2_display:.6f}"
+    )
+
+    isect_delta = cb["n_isects"] - base["n_isects"]
+    isect_ratio = 0.0
+    if base["n_isects"] > 0:
+        isect_ratio = 100.0 * (cb["n_isects"] / base["n_isects"] - 1.0)
+    speedup = 0.0
+    if cb["avg_ms"] > 0:
+        speedup = base["avg_ms"] / cb["avg_ms"]
+
+    print("\n[Delta: CB - Baseline]")
+    print(f"n_isects_delta={isect_delta} ({isect_ratio:+.2f}%)")
+    print(f"avg_render_ms_speedup={speedup:.4f}x")
+    print(
+        "image_diff "
+        f"max_abs={format_float(diff['max_abs'])} "
+        f"mean_abs={format_float(diff['mean_abs'])} "
+        f"rmse={format_float(diff['rmse'])} "
+        f"psnr={format_float(diff['psnr'])}"
+    )
+
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/examples/benchmark_compact_box.py
+++ b/examples/benchmark_compact_box.py
@@ -36,6 +36,7 @@ class Config:
     packed: bool = False
     compact_box_mult: float = 1.0
     compact_box_tau2: Optional[float] = None
+    compact_box_impl: str = "sweep"
     sweep_mults: Optional[list[float]] = None
     device: str = "cuda"
 
@@ -93,6 +94,7 @@ def run_mode(
     compact_box: bool,
     compact_box_mult: float,
     compact_box_tau2: Optional[float],
+    compact_box_impl: str,
 ) -> ModeResult:
     last_render = None
     last_meta = None
@@ -114,6 +116,7 @@ def run_mode(
         "compact_box": compact_box,
         "compact_box_mult": compact_box_mult,
         "compact_box_tau2": compact_box_tau2,
+        "compact_box_impl": compact_box_impl,
     }
 
     for _ in range(warmup):
@@ -213,6 +216,7 @@ def main(cfg: Config) -> None:
         compact_box=False,
         compact_box_mult=1,
         compact_box_tau2=None,
+        compact_box_impl=cfg.compact_box_impl,
     )
     print("\n[Baseline]")
     print_mode("baseline", base)
@@ -239,6 +243,7 @@ def main(cfg: Config) -> None:
                 compact_box=True,
                 compact_box_mult=float(mult),
                 compact_box_tau2=None,
+                compact_box_impl=cfg.compact_box_impl,
             )
             diff = image_diff_metrics(base["render"], cb["render"])
             speedup = base["avg_ms"] / cb["avg_ms"] if cb["avg_ms"] > 0 else 0.0
@@ -264,6 +269,7 @@ def main(cfg: Config) -> None:
         compact_box=True,
         compact_box_mult=cfg.compact_box_mult,
         compact_box_tau2=cfg.compact_box_tau2,
+        compact_box_impl=cfg.compact_box_impl,
     )
 
     diff = image_diff_metrics(base["render"], cb["render"])
@@ -274,7 +280,11 @@ def main(cfg: Config) -> None:
         if cfg.compact_box_tau2 is not None
         else "tau2=mult*2*log(opacity*255)"
     )
-    print_mode("compact_box", cb, extra=f"mult={cfg.compact_box_mult:.4f} {tau_text}")
+    print_mode(
+        "compact_box",
+        cb,
+        extra=f"impl={cfg.compact_box_impl} mult={cfg.compact_box_mult:.4f} {tau_text}",
+    )
 
     isect_delta = cb["n_isects"] - base["n_isects"]
     isect_ratio = 0.0

--- a/examples/benchmark_compact_box_2dgs.py
+++ b/examples/benchmark_compact_box_2dgs.py
@@ -1,0 +1,306 @@
+"""Compact Box A/B benchmark for 2DGS with synthetic splats.
+
+Example:
+    python examples/benchmark_compact_box_2dgs.py --iters 20 --warmup 5
+"""
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, TypedDict
+
+import torch
+import torch.nn.functional as F
+import tyro
+
+from gsplat.rendering import rasterization_2dgs
+
+
+class ModeResult(TypedDict):
+    render: torch.Tensor
+    meta: Dict[str, Any]
+    avg_ms: float
+    n_isects: int
+    tiles_mean: float
+
+
+@dataclass
+class Config:
+    seed: int = 42
+    gaussians: int = 120000
+    cameras: int = 2
+    width: int = 1280
+    height: int = 720
+    warmup: int = 10
+    iters: int = 50
+    compact_box_mult: float = 1.0
+    compact_box_tau2: Optional[float] = None
+    compact_box_impl: str = "sweep"
+    sweep_mults: Optional[list[float]] = None
+    device: str = "cuda"
+
+
+def make_synthetic_scene(
+    device: torch.device,
+    n_gaussians: int,
+    n_cameras: int,
+    width: int,
+    height: int,
+) -> Dict[str, torch.Tensor]:
+    means = torch.empty(n_gaussians, 3, device=device)
+    means[:, 0] = torch.randn(n_gaussians, device=device) * 1.2
+    means[:, 1] = torch.randn(n_gaussians, device=device) * 0.8
+    means[:, 2] = torch.rand(n_gaussians, device=device) * 3.0 + 1.0
+
+    quats = F.normalize(torch.randn(n_gaussians, 4, device=device), dim=-1)
+    scales = torch.ones(n_gaussians, 3, device=device)
+    scales[:, 0] = torch.rand(n_gaussians, device=device) * 0.08 + 0.01
+    scales[:, 1] = torch.rand(n_gaussians, device=device) * 0.08 + 0.01
+    opacities = torch.sigmoid(torch.randn(n_gaussians, device=device) * 0.5)
+    colors = torch.rand(n_gaussians, 3, device=device)
+
+    viewmats = torch.eye(4, device=device).unsqueeze(0).repeat(n_cameras, 1, 1)
+    if n_cameras > 1:
+        offsets = torch.linspace(-0.08, 0.08, steps=n_cameras, device=device)
+        viewmats[:, 0, 3] = -offsets
+
+    focal = 0.9 * float(max(width, height))
+    Ks = torch.tensor(
+        [[focal, 0.0, width / 2.0], [0.0, focal, height / 2.0], [0.0, 0.0, 1.0]],
+        device=device,
+        dtype=torch.float32,
+    ).unsqueeze(0)
+    Ks = Ks.repeat(n_cameras, 1, 1)
+
+    return {
+        "means": means,
+        "quats": quats,
+        "scales": scales,
+        "opacities": opacities,
+        "colors": colors,
+        "viewmats": viewmats,
+        "Ks": Ks,
+    }
+
+
+@torch.no_grad()
+def run_mode(
+    scene: Dict[str, torch.Tensor],
+    width: int,
+    height: int,
+    warmup: int,
+    iters: int,
+    compact_box: bool,
+    compact_box_mult: float,
+    compact_box_tau2: Optional[float],
+    compact_box_impl: str,
+) -> ModeResult:
+    last_render = None
+    last_meta = None
+
+    if scene["means"].is_cuda:
+        torch.cuda.synchronize(scene["means"].device)
+
+    raster_kwargs: Dict[str, Any] = {
+        "means": scene["means"],
+        "quats": scene["quats"],
+        "scales": scene["scales"],
+        "opacities": scene["opacities"],
+        "colors": scene["colors"],
+        "viewmats": scene["viewmats"],
+        "Ks": scene["Ks"],
+        "width": width,
+        "height": height,
+        "packed": False,
+        "compact_box": compact_box,
+        "compact_box_mult": compact_box_mult,
+        "compact_box_tau2": compact_box_tau2,
+        "compact_box_impl": compact_box_impl,
+    }
+
+    for _ in range(warmup):
+        last_render, _, _, _, _, _, last_meta = rasterization_2dgs(**raster_kwargs)
+
+    if scene["means"].is_cuda:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            last_render, _, _, _, _, _, last_meta = rasterization_2dgs(**raster_kwargs)
+        end.record()
+        torch.cuda.synchronize(scene["means"].device)
+        avg_ms = start.elapsed_time(end) / float(iters)
+    else:
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            last_render, _, _, _, _, _, last_meta = rasterization_2dgs(**raster_kwargs)
+        t1 = time.perf_counter()
+        avg_ms = (t1 - t0) * 1000.0 / float(iters)
+
+    assert last_render is not None and last_meta is not None
+
+    tiles_per_gauss = last_meta["tiles_per_gauss"].float()
+    n_isects = int(last_meta["isect_ids"].numel())
+    out: ModeResult = {
+        "render": last_render,
+        "meta": last_meta,
+        "avg_ms": avg_ms,
+        "n_isects": n_isects,
+        "tiles_mean": float(tiles_per_gauss.mean().item()),
+    }
+    return out
+
+
+def image_diff_metrics(a: torch.Tensor, b: torch.Tensor) -> Dict[str, float]:
+    diff = (a - b).abs()
+    max_abs = float(diff.max().item())
+    mean_abs = float(diff.mean().item())
+    mse = float(((a - b) ** 2).mean().item())
+    rmse = math.sqrt(max(mse, 0.0))
+    if mse <= 1e-20:
+        psnr = float("inf")
+    else:
+        psnr = 10.0 * math.log10(1.0 / mse)
+    return {
+        "max_abs": max_abs,
+        "mean_abs": mean_abs,
+        "mse": mse,
+        "rmse": rmse,
+        "psnr": psnr,
+    }
+
+
+def format_float(x: float) -> str:
+    if math.isinf(x):
+        return "inf"
+    return f"{x:.6f}"
+
+
+def print_mode(name: str, result: ModeResult, extra: str = "") -> None:
+    suffix = f" {extra}" if extra else ""
+    print(
+        f"{name}: avg_render_ms={result['avg_ms']:.3f} "
+        f"n_isects={result['n_isects']} "
+        f"tiles_per_gauss_mean={result['tiles_mean']:.4f}{suffix}"
+    )
+
+
+def main(cfg: Config) -> None:
+    device = torch.device(cfg.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available, but --device=cuda was requested")
+
+    torch.manual_seed(cfg.seed)
+    scene = make_synthetic_scene(
+        device=device,
+        n_gaussians=cfg.gaussians,
+        n_cameras=cfg.cameras,
+        width=cfg.width,
+        height=cfg.height,
+    )
+
+    print("=== Compact Box A/B Benchmark (2DGS) ===")
+    print(
+        f"device={device} gaussians={cfg.gaussians} cameras={cfg.cameras} "
+        f"resolution={cfg.width}x{cfg.height} tile_size=16"
+    )
+
+    base = run_mode(
+        scene=scene,
+        width=cfg.width,
+        height=cfg.height,
+        warmup=cfg.warmup,
+        iters=cfg.iters,
+        compact_box=False,
+        compact_box_mult=1,
+        compact_box_tau2=None,
+        compact_box_impl=cfg.compact_box_impl,
+    )
+    print("\n[Baseline]")
+    print_mode("baseline", base)
+
+    if cfg.sweep_mults is not None and cfg.compact_box_tau2 is not None:
+        raise ValueError(
+            "sweep_mults and compact_box_tau2 cannot be used together. "
+            "Set compact_box_tau2=None for mult sweep."
+        )
+
+    if cfg.sweep_mults:
+        print("\n[Sweep: CompactBox mult]")
+        print(
+            "mult, avg_render_ms, n_isects, tiles_per_gauss_mean, speedup_x, n_isects_delta_pct, psnr"
+        )
+        for mult in cfg.sweep_mults:
+            cb = run_mode(
+                scene=scene,
+                width=cfg.width,
+                height=cfg.height,
+                warmup=cfg.warmup,
+                iters=cfg.iters,
+                compact_box=True,
+                compact_box_mult=float(mult),
+                compact_box_tau2=None,
+                compact_box_impl=cfg.compact_box_impl,
+            )
+            diff = image_diff_metrics(base["render"], cb["render"])
+            speedup = base["avg_ms"] / cb["avg_ms"] if cb["avg_ms"] > 0 else 0.0
+            isect_ratio = (
+                100.0 * (cb["n_isects"] / base["n_isects"] - 1.0)
+                if base["n_isects"] > 0
+                else 0.0
+            )
+            print(
+                f"{mult:.4f}, {cb['avg_ms']:.3f}, {cb['n_isects']}, "
+                f"{cb['tiles_mean']:.4f}, {speedup:.4f}, {isect_ratio:+.2f}, "
+                f"{format_float(diff['psnr'])}"
+            )
+        return
+
+    cb = run_mode(
+        scene=scene,
+        width=cfg.width,
+        height=cfg.height,
+        warmup=cfg.warmup,
+        iters=cfg.iters,
+        compact_box=True,
+        compact_box_mult=cfg.compact_box_mult,
+        compact_box_tau2=cfg.compact_box_tau2,
+        compact_box_impl=cfg.compact_box_impl,
+    )
+
+    diff = image_diff_metrics(base["render"], cb["render"])
+
+    print("\n[CompactBox]")
+    tau_text = (
+        f"tau2_override={cfg.compact_box_tau2:.6f}"
+        if cfg.compact_box_tau2 is not None
+        else "tau2=mult*2*log(opacity*255)"
+    )
+    print_mode(
+        "compact_box",
+        cb,
+        extra=f"impl={cfg.compact_box_impl} mult={cfg.compact_box_mult:.4f} {tau_text}",
+    )
+
+    isect_delta = cb["n_isects"] - base["n_isects"]
+    isect_ratio = 0.0
+    if base["n_isects"] > 0:
+        isect_ratio = 100.0 * (cb["n_isects"] / base["n_isects"] - 1.0)
+    speedup = 0.0
+    if cb["avg_ms"] > 0:
+        speedup = base["avg_ms"] / cb["avg_ms"]
+
+    print("\n[Delta: CB - Baseline]")
+    print(f"n_isects_delta={isect_delta} ({isect_ratio:+.2f}%)")
+    print(f"avg_render_ms_speedup={speedup:.4f}x")
+    print(
+        "image_diff "
+        f"max_abs={format_float(diff['max_abs'])} "
+        f"mean_abs={format_float(diff['mean_abs'])} "
+        f"rmse={format_float(diff['rmse'])} "
+        f"psnr={format_float(diff['psnr'])}"
+    )
+
+
+if __name__ == "__main__":
+    main(tyro.cli(Config))

--- a/examples/simple_trainer_2dgs.py
+++ b/examples/simple_trainer_2dgs.py
@@ -118,6 +118,14 @@ class Config:
     antialiased: bool = False
     # Whether to use revised opacity heuristic from arXiv:2404.06109 (experimental)
     revised_opacity: bool = False
+    # Enable Compact Box tile pruning in 2DGS rasterization.
+    compact_box: bool = False
+    # Compact Box opacity-coupled multiplier (used only when compact_box_tau2 is None).
+    compact_box_mult: float = 1.0
+    # Optional Compact Box tau2 override.
+    compact_box_tau2: Optional[float] = None
+    # Compact Box implementation.
+    compact_box_impl: Literal["rect_min", "sweep"] = "sweep"
 
     # Use random background for training to discourage transparency
     random_bkgd: bool = False
@@ -431,6 +439,10 @@ class Runner:
                 width=width,
                 height=height,
                 packed=self.cfg.packed,
+                compact_box=self.cfg.compact_box,
+                compact_box_mult=self.cfg.compact_box_mult,
+                compact_box_tau2=self.cfg.compact_box_tau2,
+                compact_box_impl=self.cfg.compact_box_impl,
                 absgrad=self.cfg.absgrad,
                 sparse_grad=self.cfg.sparse_grad,
                 **kwargs,
@@ -633,7 +645,7 @@ class Runner:
 
             loss.backward()
 
-            desc = f"loss={loss.item():.3f}| " f"sh degree={sh_degree_to_use}| "
+            desc = f"loss={loss.item():.3f}| sh degree={sh_degree_to_use}| "
             if cfg.depth_loss:
                 desc += f"depth loss={depthloss.item():.6f}| "
             if cfg.dist_loss:

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -361,6 +361,7 @@ def isect_tiles(
     compact_box_mult: float = 1.0,
     compact_box_tau2: Optional[float] = None,
     compact_box_impl: Literal["rect_min", "sweep"] = "sweep",
+    ray_transforms: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Maps projected Gaussians to intersecting tiles.
 
@@ -379,7 +380,10 @@ def isect_tiles(
         opacities: Gaussian opacities used by Compact Box thresholding.
             Required only when compact_box is enabled.
         conics: Inverse projected covariance values (q00, q01, q11). Required only
-            when compact_box is enabled.
+            when compact_box is enabled for 3DGS.
+        ray_transforms: 2DGS ray transforms used to derive Compact Box conics
+            from homography geometry. Required only when compact_box is enabled
+            for 2DGS.
         compact_box: If True, enable Mahalanobis compact-box pruning at tile-pair
             generation. Default: False.
         compact_box_mult: User-facing compactness multiplier used only when
@@ -420,20 +424,33 @@ def isect_tiles(
         assert radii.shape == (C, N), radii.size()
         assert depths.shape == (C, N), depths.size()
 
-    if conics is not None:
-        conics = conics.contiguous()
     if opacities is not None:
         opacities = opacities.contiguous()
+    if conics is not None:
+        conics = conics.contiguous()
+    if ray_transforms is not None:
+        ray_transforms = ray_transforms.contiguous()
+
+    if packed:
+        if conics is not None:
+            assert conics.shape == (nnz, 3), conics.size()
+        if opacities is not None:
+            assert opacities.shape == (nnz,), opacities.size()
+        if ray_transforms is not None:
+            assert ray_transforms.shape == (nnz, 3, 3), ray_transforms.size()
+    else:
+        if conics is not None:
+            assert conics.shape == (C, N, 3), conics.size()
+        if opacities is not None:
+            assert opacities.shape == (C, N), opacities.size()
+        if ray_transforms is not None:
+            assert ray_transforms.shape == (C, N, 3, 3), ray_transforms.size()
 
     if compact_box:
         assert opacities is not None, "opacities is required when compact_box is True"
-        assert conics is not None, "conics is required when compact_box is True"
-        if packed:
-            assert opacities.shape == (nnz,), opacities.size()
-            assert conics.shape == (nnz, 3), conics.size()
-        else:
-            assert opacities.shape == (C, N), opacities.size()
-            assert conics.shape == (C, N, 3), conics.size()
+        assert (conics is not None) or (ray_transforms is not None), (
+            "conics (3DGS) or ray_transforms (2DGS) is required when compact_box is True"
+        )
         compact_box_mult = float(compact_box_mult)
         assert compact_box_impl in ("rect_min", "sweep"), compact_box_impl
         compact_box_use_sweep = compact_box_impl == "sweep"
@@ -453,6 +470,7 @@ def isect_tiles(
         radii.contiguous(),
         depths.contiguous(),
         conics,
+        ray_transforms,
         opacities,
         camera_ids,
         gaussian_ids,

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -360,6 +360,7 @@ def isect_tiles(
     compact_box: bool = False,
     compact_box_mult: float = 1.0,
     compact_box_tau2: Optional[float] = None,
+    compact_box_impl: Literal["rect_min", "sweep"] = "sweep",
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Maps projected Gaussians to intersecting tiles.
 
@@ -386,6 +387,9 @@ def isect_tiles(
             opacity. Default: 1.0.
         compact_box_tau2: Explicit squared Mahalanobis threshold. If provided,
             this overrides compact_box_mult.
+        compact_box_impl: Compact Box implementation. "rect_min" uses
+            per-tile rectangle minimum testing, "sweep" uses a slice-based
+            span traversal. Default: "sweep".
 
     Returns:
         A tuple:
@@ -431,12 +435,15 @@ def isect_tiles(
             assert opacities.shape == (C, N), opacities.size()
             assert conics.shape == (C, N, 3), conics.size()
         compact_box_mult = float(compact_box_mult)
+        assert compact_box_impl in ("rect_min", "sweep"), compact_box_impl
+        compact_box_use_sweep = compact_box_impl == "sweep"
         compact_box_use_global_tau2 = compact_box_tau2 is not None
         compact_box_tau2 = (
             float(compact_box_tau2) if compact_box_use_global_tau2 else 0.0
         )
     else:
         compact_box_use_global_tau2 = False
+        compact_box_use_sweep = False
         compact_box_tau2 = 0.0
         compact_box_mult = 1.0
 
@@ -457,6 +464,7 @@ def isect_tiles(
         compact_box_mult,
         compact_box_tau2,
         compact_box_use_global_tau2,
+        compact_box_use_sweep,
         sort,
         True,  # DoubleBuffer: memory efficient radixsort
     )

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -355,6 +355,10 @@ def isect_tiles(
     n_cameras: Optional[int] = None,
     camera_ids: Optional[Tensor] = None,
     gaussian_ids: Optional[Tensor] = None,
+    conics: Optional[Tensor] = None,
+    compact_box: bool = False,
+    compact_box_mult: float = 1.0,
+    compact_box_tau2: Optional[float] = None,
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Maps projected Gaussians to intersecting tiles.
 
@@ -370,6 +374,15 @@ def isect_tiles(
         n_cameras: Number of cameras. Required if packed is True.
         camera_ids: The row indices of the projected Gaussians. Required if packed is True.
         gaussian_ids: The column indices of the projected Gaussians. Required if packed is True.
+        conics: Inverse projected covariance values (q00, q01, q11). Required only
+            when compact_box is enabled.
+        compact_box: If True, enable Mahalanobis compact-box pruning at tile-pair
+            generation. Default: False.
+        compact_box_mult: User-facing compactness multiplier used only when
+            compact_box_tau2 is None. Provisional mapping: tau2 = 9 * mult^2.
+            Default: 1.0.
+        compact_box_tau2: Explicit squared Mahalanobis threshold. If provided,
+            this overrides compact_box_mult.
 
     Returns:
         A tuple:
@@ -400,16 +413,33 @@ def isect_tiles(
         assert radii.shape == (C, N), radii.size()
         assert depths.shape == (C, N), depths.size()
 
+    if compact_box:
+        assert conics is not None, "conics is required when compact_box is True"
+        if packed:
+            assert conics.shape == (nnz, 3), conics.size()
+        else:
+            assert conics.shape == (C, N, 3), conics.size()
+        if compact_box_tau2 is None:
+            compact_box_tau2 = 9.0 * float(compact_box_mult) * float(compact_box_mult)
+        compact_box_tau2 = float(compact_box_tau2)
+        assert compact_box_tau2 >= 0.0, compact_box_tau2
+        conics = conics.contiguous()
+    else:
+        compact_box_tau2 = 0.0
+
     tiles_per_gauss, isect_ids, flatten_ids = _make_lazy_cuda_func("isect_tiles")(
         means2d.contiguous(),
         radii.contiguous(),
         depths.contiguous(),
+        conics,
         camera_ids,
         gaussian_ids,
         C,
         tile_size,
         tile_width,
         tile_height,
+        compact_box,
+        compact_box_tau2,
         sort,
         True,  # DoubleBuffer: memory efficient radixsort
     )
@@ -544,12 +574,12 @@ def rasterize_to_pixels(
         padded_channels = 0
 
     tile_height, tile_width = isect_offsets.shape[1:3]
-    assert (
-        tile_height * tile_size >= image_height
-    ), f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
-    assert (
-        tile_width * tile_size >= image_width
-    ), f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    assert tile_height * tile_size >= image_height, (
+        f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
+    )
+    assert tile_width * tile_size >= image_width, (
+        f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    )
 
     render_colors, render_alphas = _RasterizeToPixels.apply(
         means2d.contiguous(),
@@ -621,12 +651,12 @@ def rasterize_to_indices_in_range(
     assert isect_offsets.shape[0] == C, isect_offsets.shape
 
     tile_height, tile_width = isect_offsets.shape[1:3]
-    assert (
-        tile_height * tile_size >= image_height
-    ), f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
-    assert (
-        tile_width * tile_size >= image_width
-    ), f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    assert tile_height * tile_size >= image_height, (
+        f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
+    )
+    assert tile_width * tile_size >= image_width, (
+        f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    )
 
     out_gauss_ids, out_indices = _make_lazy_cuda_func("rasterize_to_indices_in_range")(
         range_start,
@@ -1558,7 +1588,6 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
             grad_K = None
             # compute the gradient with respect to K.
         else:
-
             T_cl = Ks.inverse() @ ray_transforms  # this matches exactly.
             visibility_filter = radii > 0
 
@@ -1908,12 +1937,12 @@ def rasterize_to_pixels_2dgs(
     else:
         padded_channels = 0
     tile_height, tile_width = isect_offsets.shape[1:3]
-    assert (
-        tile_height * tile_size >= image_height
-    ), f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
-    assert (
-        tile_width * tile_size >= image_width
-    ), f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    assert tile_height * tile_size >= image_height, (
+        f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
+    )
+    assert tile_width * tile_size >= image_width, (
+        f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    )
 
     (
         render_colors,
@@ -1995,12 +2024,12 @@ def rasterize_to_indices_in_range_2dgs(
     assert isect_offsets.shape[0] == C, isect_offsets.shape
 
     tile_height, tile_width = isect_offsets.shape[1:3]
-    assert (
-        tile_height * tile_size >= image_height
-    ), f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
-    assert (
-        tile_width * tile_size >= image_width
-    ), f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    assert tile_height * tile_size >= image_height, (
+        f"Assert Failed: {tile_height} * {tile_size} >= {image_height}"
+    )
+    assert tile_width * tile_size >= image_width, (
+        f"Assert Failed: {tile_width} * {tile_size} >= {image_width}"
+    )
 
     out_gauss_ids, out_indices = _make_lazy_cuda_func(
         "rasterize_to_indices_in_range_2dgs"
@@ -2108,7 +2137,6 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
         v_render_distort: Tensor,
         v_render_median: Tensor,
     ):
-
         (
             means2d,
             ray_transforms,

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -2234,7 +2234,6 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             v_render_median.contiguous(),
             absgrad,
         )
-        torch.cuda.synchronize()
         if absgrad:
             means2d.absgrad = v_means2d_abs
 

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -355,6 +355,7 @@ def isect_tiles(
     n_cameras: Optional[int] = None,
     camera_ids: Optional[Tensor] = None,
     gaussian_ids: Optional[Tensor] = None,
+    opacities: Optional[Tensor] = None,
     conics: Optional[Tensor] = None,
     compact_box: bool = False,
     compact_box_mult: float = 1.0,
@@ -374,13 +375,15 @@ def isect_tiles(
         n_cameras: Number of cameras. Required if packed is True.
         camera_ids: The row indices of the projected Gaussians. Required if packed is True.
         gaussian_ids: The column indices of the projected Gaussians. Required if packed is True.
+        opacities: Gaussian opacities used by Compact Box thresholding.
+            Required only when compact_box is enabled.
         conics: Inverse projected covariance values (q00, q01, q11). Required only
             when compact_box is enabled.
         compact_box: If True, enable Mahalanobis compact-box pruning at tile-pair
             generation. Default: False.
         compact_box_mult: User-facing compactness multiplier used only when
-            compact_box_tau2 is None. Provisional mapping: tau2 = 9 * mult^2.
-            Default: 1.0.
+            compact_box_tau2 is None, where tau2 is derived per-Gaussian from
+            opacity. Default: 1.0.
         compact_box_tau2: Explicit squared Mahalanobis threshold. If provided,
             this overrides compact_box_mult.
 
@@ -413,25 +416,37 @@ def isect_tiles(
         assert radii.shape == (C, N), radii.size()
         assert depths.shape == (C, N), depths.size()
 
+    if conics is not None:
+        conics = conics.contiguous()
+    if opacities is not None:
+        opacities = opacities.contiguous()
+
     if compact_box:
+        assert opacities is not None, "opacities is required when compact_box is True"
         assert conics is not None, "conics is required when compact_box is True"
         if packed:
+            assert opacities.shape == (nnz,), opacities.size()
             assert conics.shape == (nnz, 3), conics.size()
         else:
+            assert opacities.shape == (C, N), opacities.size()
             assert conics.shape == (C, N, 3), conics.size()
-        if compact_box_tau2 is None:
-            compact_box_tau2 = 9.0 * float(compact_box_mult) * float(compact_box_mult)
-        compact_box_tau2 = float(compact_box_tau2)
-        assert compact_box_tau2 >= 0.0, compact_box_tau2
-        conics = conics.contiguous()
+        compact_box_mult = float(compact_box_mult)
+        compact_box_use_global_tau2 = compact_box_tau2 is not None
+        compact_box_tau2 = (
+            float(compact_box_tau2) if compact_box_use_global_tau2 else 0.0
+        )
     else:
+        compact_box_use_global_tau2 = False
         compact_box_tau2 = 0.0
+        compact_box_mult = 1.0
 
-    tiles_per_gauss, isect_ids, flatten_ids = _make_lazy_cuda_func("isect_tiles")(
+    isect_tiles_cuda = _make_lazy_cuda_func("isect_tiles")
+    tiles_per_gauss, isect_ids, flatten_ids = isect_tiles_cuda(
         means2d.contiguous(),
         radii.contiguous(),
         depths.contiguous(),
         conics,
+        opacities,
         camera_ids,
         gaussian_ids,
         C,
@@ -439,7 +454,9 @@ def isect_tiles(
         tile_width,
         tile_height,
         compact_box,
+        compact_box_mult,
         compact_box_tau2,
+        compact_box_use_global_tau2,
         sort,
         True,  # DoubleBuffer: memory efficient radixsort
     )

--- a/gsplat/cuda/csrc/isect_tiles.cu
+++ b/gsplat/cuda/csrc/isect_tiles.cu
@@ -131,13 +131,16 @@ __global__ void isect_tiles(
     const int32_t *__restrict__ radii,               // [C, N] or [nnz]
     const T *__restrict__ depths,                    // [C, N] or [nnz]
     const T *__restrict__ conics,                    // [C, N, 3] or [nnz, 3]
+    const T *__restrict__ opacities,                 // [C, N] or [nnz]
     const int64_t *__restrict__ cum_tiles_per_gauss, // [C, N] or [nnz]
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
     const uint32_t tile_n_bits,
     const bool compact_box,
+    const float compact_box_mult,
     const float compact_box_tau2,
+    const bool compact_box_use_global_tau2,
     int32_t *__restrict__ tiles_per_gauss, // [C, N] or [nnz]
     int64_t *__restrict__ isect_ids,       // [n_isects]
     int32_t *__restrict__ flatten_ids      // [n_isects]
@@ -181,11 +184,32 @@ __global__ void isect_tiles(
 
     OpT q00 = static_cast<OpT>(0.0), q01 = static_cast<OpT>(0.0),
         q11 = static_cast<OpT>(0.0);
+    OpT cb_tau2 = static_cast<OpT>(0.0);
+    bool cb_valid = compact_box;
     if (compact_box) {
         // Conic layout is [q00, q01, q11] per projected Gaussian.
         q00 = conics[3 * idx];
         q01 = conics[3 * idx + 1];
         q11 = conics[3 * idx + 2];
+
+        constexpr OpT cb_eps = static_cast<OpT>(1e-12);
+        const OpT det = q00 * q11 - q01 * q01;
+        cb_valid = (q00 > static_cast<OpT>(0.0)) &&
+                   (q11 > static_cast<OpT>(0.0)) && (det > cb_eps);
+        if (cb_valid) {
+            if (compact_box_use_global_tau2) {
+                cb_tau2 = static_cast<OpT>(compact_box_tau2);
+            } else {
+                const OpT opacity_safe = max(
+                    opacities[idx],
+                    static_cast<OpT>(1e-9)
+                );
+                cb_tau2 = static_cast<OpT>(compact_box_mult) *
+                          static_cast<OpT>(2.0) *
+                          log(opacity_safe * static_cast<OpT>(255.0));
+            }
+            cb_valid = cb_tau2 > static_cast<OpT>(0.0);
+        }
     }
 
     if (first_pass) {
@@ -195,6 +219,10 @@ __global__ void isect_tiles(
             tiles_per_gauss[idx] = static_cast<int32_t>(
                 (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
             );
+            return;
+        }
+        if (!cb_valid) {
+            tiles_per_gauss[idx] = 0;
             return;
         }
 
@@ -212,7 +240,7 @@ __global__ void isect_tiles(
                         q00,
                         q01,
                         q11,
-                        static_cast<OpT>(compact_box_tau2)
+                        cb_tau2
                     )) {
                     continue;
                 }
@@ -239,6 +267,9 @@ __global__ void isect_tiles(
     // Reinterpret depth bits and append to low 32 bits for stable depth sorting.
     int64_t depth_id_enc = (int64_t) * (int32_t *)&(depths[idx]);
     int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
+    if (compact_box && !cb_valid) {
+        return;
+    }
     for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
         for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
             if (compact_box &&
@@ -251,7 +282,7 @@ __global__ void isect_tiles(
                     q00,
                     q01,
                     q11,
-                    static_cast<OpT>(compact_box_tau2)
+                    cb_tau2
                 )) {
                 continue;
             }
@@ -272,6 +303,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const torch::Tensor &radii,                      // [C, N] or [nnz]
     const torch::Tensor &depths,                     // [C, N] or [nnz]
     const at::optional<torch::Tensor> &conics,       // [C, N, 3] or [nnz, 3]
+    const at::optional<torch::Tensor> &opacities,    // [C, N] or [nnz]
     const at::optional<torch::Tensor> &camera_ids,   // [nnz]
     const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
     const uint32_t C,
@@ -279,7 +311,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const uint32_t tile_width,
     const uint32_t tile_height,
     const bool compact_box,
+    const float compact_box_mult,
     const float compact_box_tau2,
+    const bool compact_box_use_global_tau2,
     const bool sort,
     const bool double_buffer
 ) {
@@ -293,12 +327,23 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
             conics.has_value(),
             "conics must be provided when compact_box is enabled"
         );
+        TORCH_CHECK(
+            opacities.has_value(),
+            "opacities must be provided when compact_box is enabled"
+        );
     }
     if (conics.has_value()) {
         GSPLAT_CHECK_INPUT(conics.value());
         TORCH_CHECK(
             conics.value().scalar_type() == means2d.scalar_type(),
             "conics and means2d must have same dtype"
+        );
+    }
+    if (opacities.has_value()) {
+        GSPLAT_CHECK_INPUT(opacities.value());
+        TORCH_CHECK(
+            opacities.value().scalar_type() == means2d.scalar_type(),
+            "opacities and means2d must have same dtype"
         );
     }
     if (camera_ids.has_value()) {
@@ -329,6 +374,12 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                 "Packed conics must have shape [nnz, 3]"
             );
         }
+        if (opacities.has_value()) {
+            TORCH_CHECK(
+                opacities.value().dim() == 1 && opacities.value().size(0) == nnz,
+                "Packed opacities must have shape [nnz]"
+            );
+        }
     } else {
         // Unpacked layout: dense [C, N, ...] tensors.
         N = means2d.size(1); // number of gaussians
@@ -340,11 +391,20 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                 "Unpacked conics must have shape [C, N, 3]"
             );
         }
+        if (opacities.has_value()) {
+            TORCH_CHECK(
+                opacities.value().dim() == 2 && opacities.value().size(0) == C &&
+                    opacities.value().size(1) == N,
+                "Unpacked opacities must have shape [C, N]"
+            );
+        }
     }
 
     // Empty tensor is safe because kernel receives nullptr when CB is off.
     const auto conics_tensor =
         conics.has_value() ? conics.value() : torch::Tensor();
+    const auto opacities_tensor =
+        opacities.has_value() ? opacities.value() : torch::Tensor();
 
     uint32_t n_tiles = tile_width * tile_height;
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
@@ -393,13 +453,20 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                               conics_tensor.data_ptr<scalar_t>()
                           )
                         : nullptr,
+                    compact_box
+                        ? reinterpret_cast<scalar_t *>(
+                              opacities_tensor.data_ptr<scalar_t>()
+                          )
+                        : nullptr,
                     nullptr,
                     tile_size,
                     tile_width,
                     tile_height,
                     tile_n_bits,
                     compact_box,
+                    compact_box_mult,
                     compact_box_tau2,
+                    compact_box_use_global_tau2,
                     tiles_per_gauss.data_ptr<int32_t>(),
                     nullptr,
                     nullptr
@@ -444,13 +511,20 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                               conics_tensor.data_ptr<scalar_t>()
                           )
                         : nullptr,
+                    compact_box
+                        ? reinterpret_cast<scalar_t *>(
+                              opacities_tensor.data_ptr<scalar_t>()
+                          )
+                        : nullptr,
                     cum_tiles_per_gauss.data_ptr<int64_t>(),
                     tile_size,
                     tile_width,
                     tile_height,
                     tile_n_bits,
                     compact_box,
+                    compact_box_mult,
                     compact_box_tau2,
+                    compact_box_use_global_tau2,
                     nullptr,
                     isect_ids.data_ptr<int64_t>(),
                     flatten_ids.data_ptr<int32_t>()

--- a/gsplat/cuda/csrc/isect_tiles.cu
+++ b/gsplat/cuda/csrc/isect_tiles.cu
@@ -13,6 +13,109 @@ namespace cg = cooperative_groups;
  ****************************************************************************/
 
 template <typename T>
+__device__ inline T cb_eval_d2(
+    const T x,
+    const T y,
+    const T q00,
+    const T q01,
+    const T q11
+) {
+    // d2 = [x y] * Q * [x y]^T where Q = [[q00, q01], [q01, q11]]. // mahalanobis distance
+    return q00 * x * x + static_cast<T>(2.0) * q01 * x * y + q11 * y * y;
+}
+
+template <typename T>
+__device__ inline T cb_rect_min_d2(
+    const T x0,
+    const T x1,
+    const T y0,
+    const T y1,
+    const T q00,
+    const T q01,
+    const T q11
+) {
+    // Exact minimum of a convex quadratic over an axis-aligned rectangle.
+    // Candidate set for convex Q:
+    // 1) 4 corners,
+    // 2) unconstrained interior minimizer (0, 0) if inside,
+    // 3) edge-wise constrained minimizers on x=x0/x1 and y=y0/y1.
+    // This avoids iterative optimization and is branch-light for CUDA.
+    T min_d2 = cb_eval_d2(x0, y0, q00, q01, q11);
+
+    // Corners.
+    min_d2 = min(min_d2, cb_eval_d2(x0, y1, q00, q01, q11));
+    min_d2 = min(min_d2, cb_eval_d2(x1, y0, q00, q01, q11));
+    min_d2 = min(min_d2, cb_eval_d2(x1, y1, q00, q01, q11));
+
+    // Interior candidate: since f is quadratic with gradient 2Q[x,y]^T,
+    // unconstrained optimum is at (0,0) in Gaussian-local coordinates.
+    if (x0 <= static_cast<T>(0.0) && x1 >= static_cast<T>(0.0) &&
+        y0 <= static_cast<T>(0.0) && y1 >= static_cast<T>(0.0)) {
+        min_d2 = min(min_d2, static_cast<T>(0.0));
+    }
+
+    // Vertical edges: fix x and solve df/dy = 0 -> y* = -q01*x/q11.
+    // Guard division for numerically tiny q11.
+    constexpr T eps = static_cast<T>(1e-12);
+    if (fabs(q11) > eps) {
+        T yx0 = -q01 * x0 / q11;
+        yx0 = min(max(yx0, y0), y1);
+        min_d2 = min(min_d2, cb_eval_d2(x0, yx0, q00, q01, q11));
+
+        T yx1 = -q01 * x1 / q11;
+        yx1 = min(max(yx1, y0), y1);
+        min_d2 = min(min_d2, cb_eval_d2(x1, yx1, q00, q01, q11));
+    }
+
+    // Horizontal edges: fix y and solve df/dx = 0 -> x* = -q01*y/q00.
+    // Guard division for numerically tiny q00.
+    if (fabs(q00) > eps) {
+        T xy0 = -q01 * y0 / q00;
+        xy0 = min(max(xy0, x0), x1);
+        min_d2 = min(min_d2, cb_eval_d2(xy0, y0, q00, q01, q11));
+
+        T xy1 = -q01 * y1 / q00;
+        xy1 = min(max(xy1, x0), x1);
+        min_d2 = min(min_d2, cb_eval_d2(xy1, y1, q00, q01, q11));
+    }
+
+    return min_d2;
+}
+
+template <typename T>
+__device__ inline bool tile_intersects_cb(
+    const T mean_x,
+    const T mean_y,
+    const int32_t tile_x,
+    const int32_t tile_y,
+    const uint32_t tile_size,
+    const T q00,
+    const T q01,
+    const T q11,
+    const T tau2
+) {
+    // Continuous tile rectangle in pixel-center coordinates.
+    // This keeps CB conservative w.r.t. rasterization at pixel centers.
+    // x in [tile_x * tile_size + 0.5, (tile_x + 1) * tile_size - 0.5]
+    // y in [tile_y * tile_size + 0.5, (tile_y + 1) * tile_size - 0.5]
+    const T tile_x0 = tile_x * static_cast<T>(tile_size) + static_cast<T>(0.5);
+    const T tile_x1 =
+        tile_x0 + static_cast<T>(tile_size) - static_cast<T>(1.0);
+    const T tile_y0 = tile_y * static_cast<T>(tile_size) + static_cast<T>(0.5);
+    const T tile_y1 =
+        tile_y0 + static_cast<T>(tile_size) - static_cast<T>(1.0);
+
+    // Shift tile bounds to Gaussian-local coordinates before evaluating d2.
+    const T x0 = tile_x0 - mean_x;
+    const T x1 = tile_x1 - mean_x;
+    const T y0 = tile_y0 - mean_y;
+    const T y1 = tile_y1 - mean_y;
+
+    const T min_d2 = cb_rect_min_d2(x0, x1, y0, y1, q00, q01, q11);
+    return min_d2 <= tau2;
+}
+
+template <typename T>
 __global__ void isect_tiles(
     // if the data is [C, N, ...] or [nnz, ...] (packed)
     const bool packed,
@@ -27,11 +130,14 @@ __global__ void isect_tiles(
     const T *__restrict__ means2d,                   // [C, N, 2] or [nnz, 2]
     const int32_t *__restrict__ radii,               // [C, N] or [nnz]
     const T *__restrict__ depths,                    // [C, N] or [nnz]
+    const T *__restrict__ conics,                    // [C, N, 3] or [nnz, 3]
     const int64_t *__restrict__ cum_tiles_per_gauss, // [C, N] or [nnz]
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
     const uint32_t tile_n_bits,
+    const bool compact_box,
+    const float compact_box_tau2,
     int32_t *__restrict__ tiles_per_gauss, // [C, N] or [nnz]
     int64_t *__restrict__ isect_ids,       // [n_isects]
     int32_t *__restrict__ flatten_ids      // [n_isects]
@@ -41,6 +147,9 @@ __global__ void isect_tiles(
 
     // parallelize over C * N.
     uint32_t idx = cg::this_grid().thread_rank();
+    // two-pass kernel:
+    // pass 1: count intersections per Gaussian (cum ptr is null)
+    // pass 2: write encoded intersection tuples
     bool first_pass = cum_tiles_per_gauss == nullptr;
     if (idx >= (packed ? nnz : C * N)) {
         return;
@@ -60,7 +169,9 @@ __global__ void isect_tiles(
     OpT tile_x = mean2d.x / static_cast<OpT>(tile_size);
     OpT tile_y = mean2d.y / static_cast<OpT>(tile_size);
 
-    // tile_min is inclusive, tile_max is exclusive
+    // Coarse candidate tile box from radius:
+    // tile_min is inclusive, tile_max is exclusive.
+    // CB (if enabled) only prunes inside this coarse box.
     uint2 tile_min, tile_max;
     tile_min.x = min(max(0, (uint32_t)floor(tile_x - tile_radius)), tile_width);
     tile_min.y =
@@ -68,11 +179,47 @@ __global__ void isect_tiles(
     tile_max.x = min(max(0, (uint32_t)ceil(tile_x + tile_radius)), tile_width);
     tile_max.y = min(max(0, (uint32_t)ceil(tile_y + tile_radius)), tile_height);
 
+    OpT q00 = static_cast<OpT>(0.0), q01 = static_cast<OpT>(0.0),
+        q11 = static_cast<OpT>(0.0);
+    if (compact_box) {
+        // Conic layout is [q00, q01, q11] per projected Gaussian.
+        q00 = conics[3 * idx];
+        q01 = conics[3 * idx + 1];
+        q11 = conics[3 * idx + 2];
+    }
+
     if (first_pass) {
-        // first pass only writes out tiles_per_gauss
-        tiles_per_gauss[idx] = static_cast<int32_t>(
-            (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
-        );
+        // First pass computes per-Gaussian pair counts used for prefix sum.
+        // It must use the same CB predicate as second pass to keep offsets valid.
+        if (!compact_box) {
+            tiles_per_gauss[idx] = static_cast<int32_t>(
+                (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
+            );
+            return;
+        }
+
+        int32_t n_tiles = 0;
+        for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
+            for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
+                // Keep if tile rectangle's minimum Mahalanobis distance
+                // is within threshold.
+                if (!tile_intersects_cb(
+                        mean2d.x,
+                        mean2d.y,
+                        j,
+                        i,
+                        tile_size,
+                        q00,
+                        q01,
+                        q11,
+                        static_cast<OpT>(compact_box_tau2)
+                    )) {
+                    continue;
+                }
+                ++n_tiles;
+            }
+        }
+        tiles_per_gauss[idx] = n_tiles;
         return;
     }
 
@@ -86,12 +233,29 @@ __global__ void isect_tiles(
         cid = idx / N;
         // gid = idx % N;
     }
+    // Upper bits carry (camera, tile), lower 32 bits carry depth ordering key.
     const int64_t cid_enc = cid << (32 + tile_n_bits);
 
+    // Reinterpret depth bits and append to low 32 bits for stable depth sorting.
     int64_t depth_id_enc = (int64_t) * (int32_t *)&(depths[idx]);
     int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
     for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
         for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
+            if (compact_box &&
+                !tile_intersects_cb(
+                    mean2d.x,
+                    mean2d.y,
+                    j,
+                    i,
+                    tile_size,
+                    q00,
+                    q01,
+                    q11,
+                    static_cast<OpT>(compact_box_tau2)
+                )) {
+                continue;
+            }
+            // Emit only surviving (camera, gaussian, tile) pairs.
             int64_t tile_id = i * tile_width + j;
             // e.g. tile_n_bits = 22:
             // camera id (10 bits) | tile id (22 bits) | depth (32 bits)
@@ -107,12 +271,15 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const torch::Tensor &means2d,                    // [C, N, 2] or [nnz, 2]
     const torch::Tensor &radii,                      // [C, N] or [nnz]
     const torch::Tensor &depths,                     // [C, N] or [nnz]
+    const at::optional<torch::Tensor> &conics,       // [C, N, 3] or [nnz, 3]
     const at::optional<torch::Tensor> &camera_ids,   // [nnz]
     const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
     const uint32_t C,
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
+    const bool compact_box,
+    const float compact_box_tau2,
     const bool sort,
     const bool double_buffer
 ) {
@@ -120,6 +287,20 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     GSPLAT_CHECK_INPUT(means2d);
     GSPLAT_CHECK_INPUT(radii);
     GSPLAT_CHECK_INPUT(depths);
+    if (compact_box) {
+        // CB needs conic Q to evaluate Mahalanobis tile distance.
+        TORCH_CHECK(
+            conics.has_value(),
+            "conics must be provided when compact_box is enabled"
+        );
+    }
+    if (conics.has_value()) {
+        GSPLAT_CHECK_INPUT(conics.value());
+        TORCH_CHECK(
+            conics.value().scalar_type() == means2d.scalar_type(),
+            "conics and means2d must have same dtype"
+        );
+    }
     if (camera_ids.has_value()) {
         GSPLAT_CHECK_INPUT(camera_ids.value());
     }
@@ -132,6 +313,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     int64_t *camera_ids_ptr = nullptr;
     int64_t *gaussian_ids_ptr = nullptr;
     if (packed) {
+        // Packed layout: 1D nnz list with explicit camera/gaussian ids.
         nnz = means2d.size(0);
         total_elems = nnz;
         TORCH_CHECK(
@@ -140,10 +322,29 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
         );
         camera_ids_ptr = camera_ids.value().data_ptr<int64_t>();
         gaussian_ids_ptr = gaussian_ids.value().data_ptr<int64_t>();
+        if (conics.has_value()) {
+            TORCH_CHECK(
+                conics.value().dim() == 2 && conics.value().size(0) == nnz &&
+                    conics.value().size(1) == 3,
+                "Packed conics must have shape [nnz, 3]"
+            );
+        }
     } else {
+        // Unpacked layout: dense [C, N, ...] tensors.
         N = means2d.size(1); // number of gaussians
         total_elems = C * N;
+        if (conics.has_value()) {
+            TORCH_CHECK(
+                conics.value().dim() == 3 && conics.value().size(0) == C &&
+                    conics.value().size(1) == N && conics.value().size(2) == 3,
+                "Unpacked conics must have shape [C, N, 3]"
+            );
+        }
     }
+
+    // Empty tensor is safe because kernel receives nullptr when CB is off.
+    const auto conics_tensor =
+        conics.has_value() ? conics.value() : torch::Tensor();
 
     uint32_t n_tiles = tile_width * tile_height;
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
@@ -158,7 +359,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     // check if we have enough bits for them.
     assert(tile_n_bits + cam_n_bits <= 32);
 
-    // first pass: compute number of tiles per gaussian
+    // First pass: count surviving tiles per gaussian.
+    // Counts include CB pruning so prefix sum reflects final output size.
     torch::Tensor tiles_per_gauss =
         torch::empty_like(depths, depths.options().dtype(torch::kInt32));
 
@@ -185,11 +387,19 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                     reinterpret_cast<scalar_t *>(means2d.data_ptr<scalar_t>()),
                     radii.data_ptr<int32_t>(),
                     depths.data_ptr<scalar_t>(),
+                    compact_box
+                        // When CB is disabled, pass nullptr to skip conic loads.
+                        ? reinterpret_cast<scalar_t *>(
+                              conics_tensor.data_ptr<scalar_t>()
+                          )
+                        : nullptr,
                     nullptr,
                     tile_size,
                     tile_width,
                     tile_height,
                     tile_n_bits,
+                    compact_box,
+                    compact_box_tau2,
                     tiles_per_gauss.data_ptr<int32_t>(),
                     nullptr,
                     nullptr
@@ -202,7 +412,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
         n_isects = 0;
     }
 
-    // second pass: compute isect_ids and flatten_ids as a packed tensor
+    // Second pass: emit intersection records into compact arrays.
     torch::Tensor isect_ids =
         torch::empty({n_isects}, depths.options().dtype(torch::kInt64));
     torch::Tensor flatten_ids =
@@ -228,11 +438,19 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                     reinterpret_cast<scalar_t *>(means2d.data_ptr<scalar_t>()),
                     radii.data_ptr<int32_t>(),
                     depths.data_ptr<scalar_t>(),
+                    compact_box
+                        // Keep same nullptr/valid-pointer contract as first pass.
+                        ? reinterpret_cast<scalar_t *>(
+                              conics_tensor.data_ptr<scalar_t>()
+                          )
+                        : nullptr,
                     cum_tiles_per_gauss.data_ptr<int64_t>(),
                     tile_size,
                     tile_width,
                     tile_height,
                     tile_n_bits,
+                    compact_box,
+                    compact_box_tau2,
                     nullptr,
                     isect_ids.data_ptr<int64_t>(),
                     flatten_ids.data_ptr<int32_t>()

--- a/gsplat/cuda/csrc/isect_tiles.cu
+++ b/gsplat/cuda/csrc/isect_tiles.cu
@@ -115,6 +115,81 @@ __device__ inline bool tile_intersects_cb(
     return min_d2 <= tau2;
 }
 
+template <typename InT, typename OutT>
+__device__ inline bool cb_derive_q_from_ray_transform(
+    const InT *__restrict__ ray_transform,
+    OutT &mean_x,
+    OutT &mean_y,
+    OutT &q00,
+    OutT &q01,
+    OutT &q11
+) {
+    // Build the dual conic S from ray transform rows (u, v, w) using
+    // S = M * diag(1, 1, -1) * M^T, where M stores rows of KWH.
+    const OutT u0 = static_cast<OutT>(ray_transform[0]);
+    const OutT u1 = static_cast<OutT>(ray_transform[1]);
+    const OutT u2 = static_cast<OutT>(ray_transform[2]);
+    const OutT v0 = static_cast<OutT>(ray_transform[3]);
+    const OutT v1 = static_cast<OutT>(ray_transform[4]);
+    const OutT v2 = static_cast<OutT>(ray_transform[5]);
+    const OutT w0 = static_cast<OutT>(ray_transform[6]);
+    const OutT w1 = static_cast<OutT>(ray_transform[7]);
+    const OutT w2 = static_cast<OutT>(ray_transform[8]);
+
+    const OutT s00 = u0 * u0 + u1 * u1 - u2 * u2;
+    const OutT s01 = u0 * v0 + u1 * v1 - u2 * v2;
+    const OutT s02 = u0 * w0 + u1 * w1 - u2 * w2;
+    const OutT s11 = v0 * v0 + v1 * v1 - v2 * v2;
+    const OutT s12 = v0 * w0 + v1 * w1 - v2 * w2;
+    const OutT s22 = w0 * w0 + w1 * w1 - w2 * w2;
+
+    constexpr OutT eps = static_cast<OutT>(1e-12);
+    if (fabs(s22) <= eps) {
+        return false;
+    }
+
+    // We only need C up to scale. Use adjugate(S) as primal conic matrix C.
+    // C = [[c00, c01, c02], [c01, c11, c12], [c02, c12, c22]].
+    const OutT c00 = s11 * s22 - s12 * s12;
+    const OutT c01 = s02 * s12 - s01 * s22;
+    const OutT c02 = s01 * s12 - s02 * s11;
+    const OutT c11 = s00 * s22 - s02 * s02;
+    const OutT c12 = s01 * s02 - s00 * s12;
+    const OutT c22 = s00 * s11 - s01 * s01;
+
+    // A = [[c00, c01], [c01, c11]], b = [c02, c12], c = c22.
+    // Center mu = -A^{-1} b, normalized precision Q = A / k,
+    // k = b^T A^{-1} b - c, so that (x-mu)^T Q (x-mu) <= 1.
+    const OutT detA = c00 * c11 - c01 * c01;
+    if (fabs(detA) <= eps) {
+        return false;
+    }
+
+    const OutT invA00 = c11 / detA;
+    const OutT invA01 = -c01 / detA;
+    const OutT invA11 = c00 / detA;
+
+    const OutT Ainv_b0 = invA00 * c02 + invA01 * c12;
+    const OutT Ainv_b1 = invA01 * c02 + invA11 * c12;
+
+    mean_x = -Ainv_b0;
+    mean_y = -Ainv_b1;
+
+    const OutT k = c02 * Ainv_b0 + c12 * Ainv_b1 - c22;
+    if (fabs(k) <= eps) {
+        return false;
+    }
+
+    q00 = c00 / k;
+    q01 = c01 / k;
+    q11 = c11 / k;
+
+    const OutT detQ = q00 * q11 - q01 * q01;
+    return (q00 > static_cast<OutT>(0.0)) &&
+           (q11 > static_cast<OutT>(0.0)) &&
+           (detQ > eps);
+}
+
 template <typename T>
 __device__ inline void cb_intersect_fixed_x(
     const T x,
@@ -434,6 +509,7 @@ __global__ void isect_tiles(
     const int32_t *__restrict__ radii,               // [C, N] or [nnz]
     const T *__restrict__ depths,                    // [C, N] or [nnz]
     const T *__restrict__ conics,                    // [C, N, 3] or [nnz, 3]
+    const T *__restrict__ ray_transforms,            // [C, N, 3, 3] or [nnz, 3, 3]
     const T *__restrict__ opacities,                 // [C, N] or [nnz]
     const int64_t *__restrict__ cum_tiles_per_gauss, // [C, N] or [nnz]
     const uint32_t tile_size,
@@ -486,55 +562,74 @@ __global__ void isect_tiles(
     tile_max.x = min(max(0, (uint32_t)ceil(tile_x + tile_radius)), tile_width);
     tile_max.y = min(max(0, (uint32_t)ceil(tile_y + tile_radius)), tile_height);
 
+    OpT cb_mean_x = mean2d.x;
+    OpT cb_mean_y = mean2d.y;
     OpT q00 = static_cast<OpT>(0.0), q01 = static_cast<OpT>(0.0),
         q11 = static_cast<OpT>(0.0);
     OpT cb_tau2 = static_cast<OpT>(0.0);
-    bool cb_valid = compact_box;
-    if (compact_box) {
-        // Conic layout is [q00, q01, q11] per projected Gaussian.
-        q00 = conics[3 * idx];
-        q01 = conics[3 * idx + 1];
-        q11 = conics[3 * idx + 2];
+    bool cb_can_prune = false;
+    bool cb_skip_all = false;
 
-        constexpr OpT cb_eps = static_cast<OpT>(1e-12);
-        const OpT det = q00 * q11 - q01 * q01;
-        cb_valid = (q00 > static_cast<OpT>(0.0)) &&
-                   (q11 > static_cast<OpT>(0.0)) && (det > cb_eps);
-        if (cb_valid) {
-            if (compact_box_use_global_tau2) {
-                cb_tau2 = static_cast<OpT>(compact_box_tau2);
-            } else {
-                const OpT opacity_safe = max(
-                    opacities[idx],
-                    static_cast<OpT>(1e-9)
-                );
-                cb_tau2 = static_cast<OpT>(compact_box_mult) *
-                          static_cast<OpT>(2.0) *
-                          log(opacity_safe * static_cast<OpT>(255.0));
+    if (compact_box) {
+        if (compact_box_use_global_tau2) {
+            cb_tau2 = static_cast<OpT>(compact_box_tau2);
+        } else {
+            const OpT opacity_safe = max(opacities[idx], static_cast<OpT>(1e-9));
+            cb_tau2 = static_cast<OpT>(compact_box_mult) *
+                      static_cast<OpT>(2.0) *
+                      log(opacity_safe * static_cast<OpT>(255.0));
+        }
+
+        // If alpha at zero distance is below the quantization threshold,
+        // this Gaussian contributes no visible pixels.
+        if (cb_tau2 <= static_cast<OpT>(0.0)) {
+            cb_skip_all = true;
+        } else if (conics != nullptr) {
+            // 3DGS path: use projected conic directly.
+            q00 = conics[3 * idx];
+            q01 = conics[3 * idx + 1];
+            q11 = conics[3 * idx + 2];
+
+            constexpr OpT cb_eps = static_cast<OpT>(1e-12);
+            const OpT det = q00 * q11 - q01 * q01;
+            cb_can_prune = (q00 > static_cast<OpT>(0.0)) &&
+                           (q11 > static_cast<OpT>(0.0)) && (det > cb_eps);
+
+            // Keep FastGS-aligned behavior for 3DGS: invalid conics are skipped.
+            if (!cb_can_prune) {
+                cb_skip_all = true;
             }
-            cb_valid = cb_tau2 > static_cast<OpT>(0.0);
+        } else if (ray_transforms != nullptr) {
+            // 2DGS path: derive a conic approximation from ray transforms.
+            cb_can_prune = cb_derive_q_from_ray_transform(
+                ray_transforms + 9 * idx,
+                cb_mean_x,
+                cb_mean_y,
+                q00,
+                q01,
+                q11
+            );
+            // If derivation fails, fall back to coarse radius-box traversal.
         }
     }
 
     if (first_pass) {
         // First pass computes per-Gaussian pair counts used for prefix sum.
         // It must use the same CB predicate as second pass to keep offsets valid.
-        if (!compact_box) {
+        if (!compact_box || !cb_can_prune) {
             tiles_per_gauss[idx] = static_cast<int32_t>(
-                (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
+                cb_skip_all
+                    ? 0
+                    : (tile_max.y - tile_min.y) * (tile_max.x - tile_min.x)
             );
-            return;
-        }
-        if (!cb_valid) {
-            tiles_per_gauss[idx] = 0;
             return;
         }
 
         int32_t n_tiles = 0;
         if (compact_box_use_sweep) {
             n_tiles = cb_emit_or_count_sweep(
-                mean2d.x,
-                mean2d.y,
+                cb_mean_x,
+                cb_mean_y,
                 tile_size,
                 tile_width,
                 tile_height,
@@ -561,8 +656,8 @@ __global__ void isect_tiles(
                     // Keep if tile rectangle's minimum Mahalanobis distance
                     // is within threshold.
                     if (!tile_intersects_cb(
-                            mean2d.x,
-                            mean2d.y,
+                            cb_mean_x,
+                            cb_mean_y,
                             j,
                             i,
                             tile_size,
@@ -597,13 +692,13 @@ __global__ void isect_tiles(
     // Reinterpret depth bits and append to low 32 bits for stable depth sorting.
     int64_t depth_id_enc = (int64_t) * (int32_t *)&(depths[idx]);
     int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
-    if (compact_box && !cb_valid) {
+    if (cb_skip_all) {
         return;
     }
-    if (compact_box && compact_box_use_sweep) {
+    if (compact_box && cb_can_prune && compact_box_use_sweep) {
         cb_emit_or_count_sweep(
-            mean2d.x,
-            mean2d.y,
+            cb_mean_x,
+            cb_mean_y,
             tile_size,
             tile_width,
             tile_height,
@@ -628,10 +723,10 @@ __global__ void isect_tiles(
     }
     for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
         for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
-            if (compact_box &&
+            if (compact_box && cb_can_prune &&
                 !tile_intersects_cb(
-                    mean2d.x,
-                    mean2d.y,
+                    cb_mean_x,
+                    cb_mean_y,
                     j,
                     i,
                     tile_size,
@@ -659,6 +754,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const torch::Tensor &radii,                      // [C, N] or [nnz]
     const torch::Tensor &depths,                     // [C, N] or [nnz]
     const at::optional<torch::Tensor> &conics,       // [C, N, 3] or [nnz, 3]
+    const at::optional<torch::Tensor> &ray_transforms, // [C, N, 3, 3] or [nnz, 3, 3]
     const at::optional<torch::Tensor> &opacities,    // [C, N] or [nnz]
     const at::optional<torch::Tensor> &camera_ids,   // [nnz]
     const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
@@ -679,10 +775,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     GSPLAT_CHECK_INPUT(radii);
     GSPLAT_CHECK_INPUT(depths);
     if (compact_box) {
-        // CB needs conic Q to evaluate Mahalanobis tile distance.
         TORCH_CHECK(
-            conics.has_value(),
-            "conics must be provided when compact_box is enabled"
+            conics.has_value() || ray_transforms.has_value(),
+            "conics (3DGS) or ray_transforms (2DGS) must be provided when compact_box is enabled"
         );
         TORCH_CHECK(
             opacities.has_value(),
@@ -694,6 +789,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
         TORCH_CHECK(
             conics.value().scalar_type() == means2d.scalar_type(),
             "conics and means2d must have same dtype"
+        );
+    }
+    if (ray_transforms.has_value()) {
+        GSPLAT_CHECK_INPUT(ray_transforms.value());
+        TORCH_CHECK(
+            ray_transforms.value().scalar_type() == means2d.scalar_type(),
+            "ray_transforms and means2d must have same dtype"
         );
     }
     if (opacities.has_value()) {
@@ -731,6 +833,15 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                 "Packed conics must have shape [nnz, 3]"
             );
         }
+        if (ray_transforms.has_value()) {
+            TORCH_CHECK(
+                ray_transforms.value().dim() == 3 &&
+                    ray_transforms.value().size(0) == nnz &&
+                    ray_transforms.value().size(1) == 3 &&
+                    ray_transforms.value().size(2) == 3,
+                "Packed ray_transforms must have shape [nnz, 3, 3]"
+            );
+        }
         if (opacities.has_value()) {
             TORCH_CHECK(
                 opacities.value().dim() == 1 && opacities.value().size(0) == nnz,
@@ -748,6 +859,16 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                 "Unpacked conics must have shape [C, N, 3]"
             );
         }
+        if (ray_transforms.has_value()) {
+            TORCH_CHECK(
+                ray_transforms.value().dim() == 4 &&
+                    ray_transforms.value().size(0) == C &&
+                    ray_transforms.value().size(1) == N &&
+                    ray_transforms.value().size(2) == 3 &&
+                    ray_transforms.value().size(3) == 3,
+                "Unpacked ray_transforms must have shape [C, N, 3, 3]"
+            );
+        }
         if (opacities.has_value()) {
             TORCH_CHECK(
                 opacities.value().dim() == 2 && opacities.value().size(0) == C &&
@@ -760,6 +881,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     // Empty tensor is safe because kernel receives nullptr when CB is off.
     const auto conics_tensor =
         conics.has_value() ? conics.value() : torch::Tensor();
+    const auto ray_transforms_tensor =
+        ray_transforms.has_value() ? ray_transforms.value() : torch::Tensor();
     const auto opacities_tensor =
         opacities.has_value() ? opacities.value() : torch::Tensor();
 
@@ -804,10 +927,15 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                     reinterpret_cast<scalar_t *>(means2d.data_ptr<scalar_t>()),
                     radii.data_ptr<int32_t>(),
                     depths.data_ptr<scalar_t>(),
-                    compact_box
+                    compact_box && conics.has_value()
                         // When CB is disabled, pass nullptr to skip conic loads.
                         ? reinterpret_cast<scalar_t *>(
                               conics_tensor.data_ptr<scalar_t>()
+                          )
+                        : nullptr,
+                    compact_box && ray_transforms.has_value()
+                        ? reinterpret_cast<scalar_t *>(
+                              ray_transforms_tensor.data_ptr<scalar_t>()
                           )
                         : nullptr,
                     compact_box
@@ -863,10 +991,15 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                     reinterpret_cast<scalar_t *>(means2d.data_ptr<scalar_t>()),
                     radii.data_ptr<int32_t>(),
                     depths.data_ptr<scalar_t>(),
-                    compact_box
+                    compact_box && conics.has_value()
                         // Keep same nullptr/valid-pointer contract as first pass.
                         ? reinterpret_cast<scalar_t *>(
                               conics_tensor.data_ptr<scalar_t>()
+                          )
+                        : nullptr,
+                    compact_box && ray_transforms.has_value()
+                        ? reinterpret_cast<scalar_t *>(
+                              ray_transforms_tensor.data_ptr<scalar_t>()
                           )
                         : nullptr,
                     compact_box

--- a/gsplat/cuda/csrc/isect_tiles.cu
+++ b/gsplat/cuda/csrc/isect_tiles.cu
@@ -116,6 +116,309 @@ __device__ inline bool tile_intersects_cb(
 }
 
 template <typename T>
+__device__ inline void cb_intersect_fixed_x(
+    const T x,
+    const T mean_x,
+    const T mean_y,
+    const T q00,
+    const T q01,
+    const T q11,
+    const T det,
+    const T tau2,
+    bool &has,
+    T &y0,
+    T &y1
+) {
+    const T dx = x - mean_x;
+    const T sqrt_term2 = q11 * tau2 - det * dx * dx;
+    if (sqrt_term2 < static_cast<T>(0.0)) {
+        has = false;
+        return;
+    }
+    const T sqrt_term = sqrt(max(sqrt_term2, static_cast<T>(0.0)));
+    const T yc = mean_y - q01 * dx / q11;
+    y0 = yc - sqrt_term / q11;
+    y1 = yc + sqrt_term / q11;
+    has = true;
+}
+
+template <typename T>
+__device__ inline void cb_intersect_fixed_y(
+    const T y,
+    const T mean_x,
+    const T mean_y,
+    const T q00,
+    const T q01,
+    const T q11,
+    const T det,
+    const T tau2,
+    bool &has,
+    T &x0,
+    T &x1
+) {
+    const T dy = y - mean_y;
+    const T sqrt_term2 = q00 * tau2 - det * dy * dy;
+    if (sqrt_term2 < static_cast<T>(0.0)) {
+        has = false;
+        return;
+    }
+    const T sqrt_term = sqrt(max(sqrt_term2, static_cast<T>(0.0)));
+    const T xc = mean_x - q01 * dy / q00;
+    x0 = xc - sqrt_term / q00;
+    x1 = xc + sqrt_term / q00;
+    has = true;
+}
+
+template <typename T>
+__device__ inline int32_t cb_emit_or_count_sweep(
+    const T mean_x,
+    const T mean_y,
+    const uint32_t tile_size,
+    const uint32_t tile_width,
+    const uint32_t tile_height,
+    const uint32_t coarse_min_x,
+    const uint32_t coarse_min_y,
+    const uint32_t coarse_max_x,
+    const uint32_t coarse_max_y,
+    const T q00,
+    const T q01,
+    const T q11,
+    const T det,
+    const T tau2,
+    const int64_t cid_enc,
+    const int64_t depth_id_enc,
+    const int32_t flatten_idx,
+    const int64_t out_start,
+    const bool write_out,
+    int64_t *__restrict__ isect_ids,
+    int32_t *__restrict__ flatten_ids
+) {
+    const T tsize = static_cast<T>(tile_size);
+
+    const T x_ext = sqrt(max(tau2 * q11 / det, static_cast<T>(0.0)));
+    const T y_ext = sqrt(max(tau2 * q00 / det, static_cast<T>(0.0)));
+
+    int32_t rect_min_x = max(
+        static_cast<int32_t>(coarse_min_x),
+        static_cast<int32_t>(floor((mean_x - x_ext) / tsize))
+    );
+    int32_t rect_max_x = min(
+        static_cast<int32_t>(coarse_max_x),
+        static_cast<int32_t>(ceil((mean_x + x_ext) / tsize))
+    );
+    int32_t rect_min_y = max(
+        static_cast<int32_t>(coarse_min_y),
+        static_cast<int32_t>(floor((mean_y - y_ext) / tsize))
+    );
+    int32_t rect_max_y = min(
+        static_cast<int32_t>(coarse_max_y),
+        static_cast<int32_t>(ceil((mean_y + y_ext) / tsize))
+    );
+
+    const int32_t x_span = rect_max_x - rect_min_x;
+    const int32_t y_span = rect_max_y - rect_min_y;
+    if (x_span <= 0 || y_span <= 0) {
+        return 0;
+    }
+
+    // Global y extrema and corresponding x locations.
+    const T arg_x_ymin = mean_x + q01 * y_ext / q00;
+    const T arg_x_ymax = mean_x - q01 * y_ext / q00;
+    const T y_min_global = mean_y - y_ext;
+    const T y_max_global = mean_y + y_ext;
+
+    // Global x extrema and corresponding y locations.
+    const T arg_y_xmin = mean_y + q01 * x_ext / q11;
+    const T arg_y_xmax = mean_y - q01 * x_ext / q11;
+    const T x_min_global = mean_x - x_ext;
+    const T x_max_global = mean_x + x_ext;
+
+    const bool sweep_y = y_span < x_span;
+    int64_t cur = out_start;
+    int32_t n_tiles = 0;
+
+    if (!sweep_y) {
+        // Sweep x-slices and compute covered y tile span for each x tile.
+        for (int32_t tx = rect_min_x; tx < rect_max_x; ++tx) {
+            const T x0 = tx * tsize;
+            const T x1 = x0 + tsize;
+
+            T v_min = static_cast<T>(1e30);
+            T v_max = static_cast<T>(-1e30);
+            bool has_any = false;
+
+            bool has = false;
+            T a = static_cast<T>(0.0), b = static_cast<T>(0.0);
+            cb_intersect_fixed_x(
+                x0,
+                mean_x,
+                mean_y,
+                q00,
+                q01,
+                q11,
+                det,
+                tau2,
+                has,
+                a,
+                b
+            );
+            if (has) {
+                v_min = min(v_min, min(a, b));
+                v_max = max(v_max, max(a, b));
+                has_any = true;
+            }
+            cb_intersect_fixed_x(
+                x1,
+                mean_x,
+                mean_y,
+                q00,
+                q01,
+                q11,
+                det,
+                tau2,
+                has,
+                a,
+                b
+            );
+            if (has) {
+                v_min = min(v_min, min(a, b));
+                v_max = max(v_max, max(a, b));
+                has_any = true;
+            }
+            if (x0 <= arg_x_ymin && arg_x_ymin < x1) {
+                v_min = min(v_min, y_min_global);
+                has_any = true;
+            }
+            if (x0 <= arg_x_ymax && arg_x_ymax < x1) {
+                v_max = max(v_max, y_max_global);
+                has_any = true;
+            }
+            if (!has_any) {
+                continue;
+            }
+
+            int32_t ty_min = max(
+                rect_min_y,
+                min(
+                    rect_max_y,
+                    static_cast<int32_t>(floor(v_min / tsize))
+                )
+            );
+            int32_t ty_max = min(
+                rect_max_y,
+                max(
+                    rect_min_y,
+                    static_cast<int32_t>(floor(v_max / tsize)) + 1
+                )
+            );
+            if (ty_max <= ty_min) {
+                continue;
+            }
+
+            n_tiles += (ty_max - ty_min);
+            if (write_out) {
+                for (int32_t ty = ty_min; ty < ty_max; ++ty) {
+                    const int64_t tile_id = ty * tile_width + tx;
+                    isect_ids[cur] = cid_enc | (tile_id << 32) | depth_id_enc;
+                    flatten_ids[cur] = flatten_idx;
+                    ++cur;
+                }
+            }
+        }
+    } else {
+        // Sweep y-slices and compute covered x tile span for each y tile.
+        for (int32_t ty = rect_min_y; ty < rect_max_y; ++ty) {
+            const T y0 = ty * tsize;
+            const T y1 = y0 + tsize;
+
+            T v_min = static_cast<T>(1e30);
+            T v_max = static_cast<T>(-1e30);
+            bool has_any = false;
+
+            bool has = false;
+            T a = static_cast<T>(0.0), b = static_cast<T>(0.0);
+            cb_intersect_fixed_y(
+                y0,
+                mean_x,
+                mean_y,
+                q00,
+                q01,
+                q11,
+                det,
+                tau2,
+                has,
+                a,
+                b
+            );
+            if (has) {
+                v_min = min(v_min, min(a, b));
+                v_max = max(v_max, max(a, b));
+                has_any = true;
+            }
+            cb_intersect_fixed_y(
+                y1,
+                mean_x,
+                mean_y,
+                q00,
+                q01,
+                q11,
+                det,
+                tau2,
+                has,
+                a,
+                b
+            );
+            if (has) {
+                v_min = min(v_min, min(a, b));
+                v_max = max(v_max, max(a, b));
+                has_any = true;
+            }
+            if (y0 <= arg_y_xmin && arg_y_xmin < y1) {
+                v_min = min(v_min, x_min_global);
+                has_any = true;
+            }
+            if (y0 <= arg_y_xmax && arg_y_xmax < y1) {
+                v_max = max(v_max, x_max_global);
+                has_any = true;
+            }
+            if (!has_any) {
+                continue;
+            }
+
+            int32_t tx_min = max(
+                rect_min_x,
+                min(
+                    rect_max_x,
+                    static_cast<int32_t>(floor(v_min / tsize))
+                )
+            );
+            int32_t tx_max = min(
+                rect_max_x,
+                max(
+                    rect_min_x,
+                    static_cast<int32_t>(floor(v_max / tsize)) + 1
+                )
+            );
+            if (tx_max <= tx_min) {
+                continue;
+            }
+
+            n_tiles += (tx_max - tx_min);
+            if (write_out) {
+                for (int32_t tx = tx_min; tx < tx_max; ++tx) {
+                    const int64_t tile_id = ty * tile_width + tx;
+                    isect_ids[cur] = cid_enc | (tile_id << 32) | depth_id_enc;
+                    flatten_ids[cur] = flatten_idx;
+                    ++cur;
+                }
+            }
+        }
+    }
+
+    return n_tiles;
+}
+
+template <typename T>
 __global__ void isect_tiles(
     // if the data is [C, N, ...] or [nnz, ...] (packed)
     const bool packed,
@@ -141,6 +444,7 @@ __global__ void isect_tiles(
     const float compact_box_mult,
     const float compact_box_tau2,
     const bool compact_box_use_global_tau2,
+    const bool compact_box_use_sweep,
     int32_t *__restrict__ tiles_per_gauss, // [C, N] or [nnz]
     int64_t *__restrict__ isect_ids,       // [n_isects]
     int32_t *__restrict__ flatten_ids      // [n_isects]
@@ -227,24 +531,50 @@ __global__ void isect_tiles(
         }
 
         int32_t n_tiles = 0;
-        for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
-            for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
-                // Keep if tile rectangle's minimum Mahalanobis distance
-                // is within threshold.
-                if (!tile_intersects_cb(
-                        mean2d.x,
-                        mean2d.y,
-                        j,
-                        i,
-                        tile_size,
-                        q00,
-                        q01,
-                        q11,
-                        cb_tau2
-                    )) {
-                    continue;
+        if (compact_box_use_sweep) {
+            n_tiles = cb_emit_or_count_sweep(
+                mean2d.x,
+                mean2d.y,
+                tile_size,
+                tile_width,
+                tile_height,
+                tile_min.x,
+                tile_min.y,
+                tile_max.x,
+                tile_max.y,
+                q00,
+                q01,
+                q11,
+                q00 * q11 - q01 * q01,
+                cb_tau2,
+                0,
+                0,
+                0,
+                0,
+                false,
+                nullptr,
+                nullptr
+            );
+        } else {
+            for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
+                for (int32_t j = tile_min.x; j < tile_max.x; ++j) {
+                    // Keep if tile rectangle's minimum Mahalanobis distance
+                    // is within threshold.
+                    if (!tile_intersects_cb(
+                            mean2d.x,
+                            mean2d.y,
+                            j,
+                            i,
+                            tile_size,
+                            q00,
+                            q01,
+                            q11,
+                            cb_tau2
+                        )) {
+                        continue;
+                    }
+                    ++n_tiles;
                 }
-                ++n_tiles;
             }
         }
         tiles_per_gauss[idx] = n_tiles;
@@ -268,6 +598,32 @@ __global__ void isect_tiles(
     int64_t depth_id_enc = (int64_t) * (int32_t *)&(depths[idx]);
     int64_t cur_idx = (idx == 0) ? 0 : cum_tiles_per_gauss[idx - 1];
     if (compact_box && !cb_valid) {
+        return;
+    }
+    if (compact_box && compact_box_use_sweep) {
+        cb_emit_or_count_sweep(
+            mean2d.x,
+            mean2d.y,
+            tile_size,
+            tile_width,
+            tile_height,
+            tile_min.x,
+            tile_min.y,
+            tile_max.x,
+            tile_max.y,
+            q00,
+            q01,
+            q11,
+            q00 * q11 - q01 * q01,
+            cb_tau2,
+            cid_enc,
+            depth_id_enc,
+            static_cast<int32_t>(idx),
+            cur_idx,
+            true,
+            isect_ids,
+            flatten_ids
+        );
         return;
     }
     for (int32_t i = tile_min.y; i < tile_max.y; ++i) {
@@ -314,6 +670,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const float compact_box_mult,
     const float compact_box_tau2,
     const bool compact_box_use_global_tau2,
+    const bool compact_box_use_sweep,
     const bool sort,
     const bool double_buffer
 ) {
@@ -467,6 +824,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                     compact_box_mult,
                     compact_box_tau2,
                     compact_box_use_global_tau2,
+                    compact_box_use_sweep,
                     tiles_per_gauss.data_ptr<int32_t>(),
                     nullptr,
                     nullptr
@@ -525,6 +883,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
                     compact_box_mult,
                     compact_box_tau2,
                     compact_box_use_global_tau2,
+                    compact_box_use_sweep,
                     nullptr,
                     isect_ids.data_ptr<int64_t>(),
                     flatten_ids.data_ptr<int32_t>()

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -149,6 +149,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const torch::Tensor &radii,                      // [C, N] or [nnz]
     const torch::Tensor &depths,                     // [C, N] or [nnz]
     const at::optional<torch::Tensor> &conics,       // [C, N, 3] or [nnz, 3]
+    const at::optional<torch::Tensor> &opacities,    // [C, N] or [nnz]
     const at::optional<torch::Tensor> &camera_ids,   // [nnz]
     const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
     const uint32_t C,
@@ -156,7 +157,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const uint32_t tile_width,
     const uint32_t tile_height,
     const bool compact_box,
+    const float compact_box_mult,
     const float compact_box_tau2,
+    const bool compact_box_use_global_tau2,
     const bool sort,
     const bool double_buffer
 );

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -148,12 +148,15 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const torch::Tensor &means2d,                    // [C, N, 2] or [nnz, 2]
     const torch::Tensor &radii,                      // [C, N] or [nnz]
     const torch::Tensor &depths,                     // [C, N] or [nnz]
+    const at::optional<torch::Tensor> &conics,       // [C, N, 3] or [nnz, 3]
     const at::optional<torch::Tensor> &camera_ids,   // [nnz]
     const at::optional<torch::Tensor> &gaussian_ids, // [nnz]
     const uint32_t C,
     const uint32_t tile_size,
     const uint32_t tile_width,
     const uint32_t tile_height,
+    const bool compact_box,
+    const float compact_box_tau2,
     const bool sort,
     const bool double_buffer
 );

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -149,6 +149,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const torch::Tensor &radii,                      // [C, N] or [nnz]
     const torch::Tensor &depths,                     // [C, N] or [nnz]
     const at::optional<torch::Tensor> &conics,       // [C, N, 3] or [nnz, 3]
+    const at::optional<torch::Tensor> &ray_transforms, // [C, N, 3, 3] or [nnz, 3, 3]
     const at::optional<torch::Tensor> &opacities,    // [C, N] or [nnz]
     const at::optional<torch::Tensor> &camera_ids,   // [nnz]
     const at::optional<torch::Tensor> &gaussian_ids, // [nnz]

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -160,6 +160,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> isect_tiles_tensor(
     const float compact_box_mult,
     const float compact_box_tau2,
     const bool compact_box_use_global_tau2,
+    const bool compact_box_use_sweep,
     const bool sort,
     const bool double_buffer
 );

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -42,6 +42,9 @@ def rasterization(
     sh_degree: Optional[int] = None,
     packed: bool = True,
     tile_size: int = 16,
+    compact_box: bool = False,
+    compact_box_mult: float = 1.0,
+    compact_box_tau2: Optional[float] = None,
     backgrounds: Optional[Tensor] = None,
     render_mode: Literal["RGB", "D", "ED", "RGB+D", "RGB+ED"] = "RGB",
     sparse_grad: bool = False,
@@ -160,6 +163,12 @@ def rasterization(
             might not be as fast. Default is True.
         tile_size: The size of the tiles for rasterization. Default is 16.
             (Note: other values are not tested)
+        compact_box: Enable Compact Box tile pruning based on projected Gaussian
+            Mahalanobis distance. Default is False.
+        compact_box_mult: User-facing compactness multiplier used only when
+            `compact_box_tau2` is None. Default is 1.0.
+        compact_box_tau2: Explicit squared Mahalanobis threshold for Compact Box.
+            If set, this overrides `compact_box_mult`.
         backgrounds: The background colors. [C, D]. Default is None.
         render_mode: The rendering mode. Supported modes are "RGB", "D", "ED", "RGB+D",
             and "RGB+ED". "RGB" renders the colored image, "D" renders the accumulated depth, and
@@ -256,9 +265,9 @@ def rasterization(
             colors.dim() == 3 and colors.shape[:2] == (C, N)
         ), colors.shape
         if distributed:
-            assert (
-                colors.dim() == 2
-            ), "Distributed mode only supports per-Gaussian colors."
+            assert colors.dim() == 2, (
+                "Distributed mode only supports per-Gaussian colors."
+            )
     else:
         # treat colors as SH coefficients, should be in shape [N, K, 3] or [C, N, K, 3]
         # Allowing for activating partial SH bands
@@ -269,9 +278,9 @@ def rasterization(
         ), colors.shape
         assert (sh_degree + 1) ** 2 <= colors.shape[-2], colors.shape
         if distributed:
-            assert (
-                colors.dim() == 3
-            ), "Distributed mode only supports per-Gaussian colors."
+            assert colors.dim() == 3, (
+                "Distributed mode only supports per-Gaussian colors."
+            )
 
     if absgrad:
         assert not distributed, "AbsGrad is not supported in distributed mode."
@@ -505,6 +514,10 @@ def rasterization(
         n_cameras=C,
         camera_ids=camera_ids,
         gaussian_ids=gaussian_ids,
+        conics=conics,
+        compact_box=compact_box,
+        compact_box_mult=compact_box_mult,
+        compact_box_tau2=compact_box_tau2,
     )
     # print("rank", world_rank, "Before isect_offset_encode")
     isect_offsets = isect_offset_encode(isect_ids, C, tile_width, tile_height)
@@ -604,7 +617,6 @@ def _rasterization(
     camera_params: Optional[Dict] = None,
     channel_chunk: int = 32,
     batch_per_iter: int = 100,
-
 ) -> Tuple[Tensor, Tensor, Dict]:
     """A version of rasterization() that utilies on PyTorch's autograd.
 
@@ -667,7 +679,7 @@ def _rasterization(
         far_plane=far_plane,
         calc_compensations=(rasterize_mode == "antialiased"),
         camera_model=camera_model,
-        camera_params=camera_params
+        camera_params=camera_params,
     )
     opacities = opacities.repeat(C, 1)  # [C, N]
     camera_ids, gaussian_ids = None, None
@@ -1147,7 +1159,9 @@ def rasterization_2dgs(
             "ED",
             "RGB+D",
             "RGB+ED",
-        ], f"distloss requires depth rendering, render_mode should be D, ED, RGB+D, RGB+ED, but got {render_mode}"
+        ], (
+            f"distloss requires depth rendering, render_mode should be D, ED, RGB+D, RGB+ED, but got {render_mode}"
+        )
 
     if sh_degree is None:
         # treat colors as post-activation values
@@ -1157,9 +1171,9 @@ def rasterization_2dgs(
         ), colors.shape
     else:
         # treat colors as SH coefficients. Allowing for activating partial SH bands
-        assert (
-            colors.dim() == 3 and colors.shape[0] == N and colors.shape[2] == 3
-        ), colors.shape
+        assert colors.dim() == 3 and colors.shape[0] == N and colors.shape[2] == 3, (
+            colors.shape
+        )
         assert (sh_degree + 1) ** 2 <= colors.shape[1], colors.shape
 
     # Compute Ray-Splat intersection transformation.

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -166,7 +166,9 @@ def rasterization(
         compact_box: Enable Compact Box tile pruning based on projected Gaussian
             Mahalanobis distance. Default is False.
         compact_box_mult: User-facing compactness multiplier used only when
-            `compact_box_tau2` is None. Default is 1.0.
+            `compact_box_tau2` is None. In that case, each Gaussian uses
+            `tau2 = compact_box_mult * 2 * log(opacity * 255)`.
+            Default is 1.0.
         compact_box_tau2: Explicit squared Mahalanobis threshold for Compact Box.
             If set, this overrides `compact_box_mult`.
         backgrounds: The background colors. [C, D]. Default is None.
@@ -514,6 +516,7 @@ def rasterization(
         n_cameras=C,
         camera_ids=camera_ids,
         gaussian_ids=gaussian_ids,
+        opacities=opacities,
         conics=conics,
         compact_box=compact_box,
         compact_box_mult=compact_box_mult,

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -1041,6 +1041,10 @@ def rasterization_2dgs(
     sh_degree: Optional[int] = None,
     packed: bool = False,
     tile_size: int = 16,
+    compact_box: bool = False,
+    compact_box_mult: float = 1.0,
+    compact_box_tau2: Optional[float] = None,
+    compact_box_impl: Literal["rect_min", "sweep"] = "sweep",
     backgrounds: Optional[Tensor] = None,
     render_mode: Literal["RGB", "D", "ED", "RGB+D", "RGB+ED"] = "RGB",
     sparse_grad: bool = False,
@@ -1081,6 +1085,17 @@ def rasterization_2dgs(
             might not be as fast. Default is True.
         tile_size: The size of the tiles for rasterization. Default is 16.
             (Note: other values are not tested)
+        compact_box: Enable Compact Box tile pruning based on a 2DGS conic
+            approximation derived from ray transforms. Default is False.
+        compact_box_mult: User-facing compactness multiplier used only when
+            `compact_box_tau2` is None. In that case, each Gaussian uses
+            `tau2 = compact_box_mult * 2 * log(opacity * 255)`.
+            Default is 1.0.
+        compact_box_tau2: Explicit squared Mahalanobis threshold for Compact Box.
+            If set, this overrides `compact_box_mult`.
+        compact_box_impl: Compact Box implementation. "rect_min" uses
+            per-tile rectangle minimum testing while "sweep" uses slice-based
+            span traversal for lower overhead. Default is "sweep".
         backgrounds: The background colors. [C, D]. Default is None.
         render_mode: The rendering mode. Supported modes are "RGB", "D", "ED", "RGB+D",
             and "RGB+ED". "RGB" renders the colored image, "D" renders the accumulated depth, and
@@ -1234,6 +1249,12 @@ def rasterization_2dgs(
         n_cameras=C,
         camera_ids=camera_ids,
         gaussian_ids=gaussian_ids,
+        opacities=opacities,
+        ray_transforms=ray_transforms,
+        compact_box=compact_box,
+        compact_box_mult=compact_box_mult,
+        compact_box_tau2=compact_box_tau2,
+        compact_box_impl=compact_box_impl,
     )
     isect_offsets = isect_offset_encode(isect_ids, C, tile_width, tile_height)
 

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -45,6 +45,7 @@ def rasterization(
     compact_box: bool = False,
     compact_box_mult: float = 1.0,
     compact_box_tau2: Optional[float] = None,
+    compact_box_impl: Literal["rect_min", "sweep"] = "sweep",
     backgrounds: Optional[Tensor] = None,
     render_mode: Literal["RGB", "D", "ED", "RGB+D", "RGB+ED"] = "RGB",
     sparse_grad: bool = False,
@@ -171,6 +172,9 @@ def rasterization(
             Default is 1.0.
         compact_box_tau2: Explicit squared Mahalanobis threshold for Compact Box.
             If set, this overrides `compact_box_mult`.
+        compact_box_impl: Compact Box implementation. "rect_min" uses
+            per-tile rectangle minimum testing while "sweep" uses slice-based
+            span traversal for lower overhead. Default is "sweep".
         backgrounds: The background colors. [C, D]. Default is None.
         render_mode: The rendering mode. Supported modes are "RGB", "D", "ED", "RGB+D",
             and "RGB+ED". "RGB" renders the colored image, "D" renders the accumulated depth, and
@@ -521,6 +525,7 @@ def rasterization(
         compact_box=compact_box,
         compact_box_mult=compact_box_mult,
         compact_box_tau2=compact_box_tau2,
+        compact_box_impl=compact_box_impl,
     )
     # print("rank", world_rank, "Before isect_offset_encode")
     isect_offsets = isect_offset_encode(isect_ids, C, tile_width, tile_height)

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -389,8 +389,224 @@ def test_rasterize_to_pixels_2dgs(test_data):
     torch.testing.assert_close(v_normals, _v_normals, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_isect_compact_box_2dgs(test_data):
+    from gsplat.cuda._wrapper import fully_fused_projection_2dgs, isect_tiles
+
+    Ks = test_data["Ks"]
+    viewmats = test_data["viewmats"]
+    height = test_data["height"]
+    width = test_data["width"]
+    quats = test_data["quats"]
+    scales = test_data["scales"]
+    means = test_data["means"]
+
+    C = viewmats.shape[0]
+    radii, means2d, depths, ray_transforms, _ = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, width, height
+    )
+
+    tile_size = 16
+    tile_width = math.ceil(width / float(tile_size))
+    tile_height = math.ceil(height / float(tile_size))
+
+    opacities = torch.full_like(depths, 0.8)
+
+    base_tiles, base_isect_ids, base_flatten_ids = isect_tiles(
+        means2d, radii, depths, tile_size, tile_width, tile_height, n_cameras=C
+    )
+    loose_tiles, loose_isect_ids, loose_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        n_cameras=C,
+        opacities=opacities,
+        ray_transforms=ray_transforms,
+        compact_box=True,
+        compact_box_tau2=1e9,
+        compact_box_impl="sweep",
+    )
+    tight_tiles, tight_isect_ids, tight_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        n_cameras=C,
+        opacities=opacities,
+        ray_transforms=ray_transforms,
+        compact_box=True,
+        compact_box_tau2=0.0,
+        compact_box_impl="sweep",
+    )
+
+    torch.testing.assert_close(base_tiles, loose_tiles)
+    torch.testing.assert_close(base_isect_ids, loose_isect_ids)
+    torch.testing.assert_close(base_flatten_ids, loose_flatten_ids)
+    assert tight_tiles.sum() <= base_tiles.sum()
+    assert tight_isect_ids.numel() <= base_isect_ids.numel()
+    assert tight_flatten_ids.numel() <= base_flatten_ids.numel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_isect_compact_box_2dgs_invalid_ray_fallback(test_data):
+    from gsplat.cuda._wrapper import fully_fused_projection_2dgs, isect_tiles
+
+    Ks = test_data["Ks"]
+    viewmats = test_data["viewmats"]
+    height = test_data["height"]
+    width = test_data["width"]
+    quats = test_data["quats"]
+    scales = test_data["scales"]
+    means = test_data["means"]
+
+    C = viewmats.shape[0]
+    radii, means2d, depths, ray_transforms, _ = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, width, height
+    )
+    bad_ray_transforms = torch.zeros_like(ray_transforms)
+
+    tile_size = 16
+    tile_width = math.ceil(width / float(tile_size))
+    tile_height = math.ceil(height / float(tile_size))
+
+    opacities = torch.full_like(depths, 0.8)
+
+    base_tiles, base_isect_ids, base_flatten_ids = isect_tiles(
+        means2d, radii, depths, tile_size, tile_width, tile_height, n_cameras=C
+    )
+    fallback_tiles, fallback_isect_ids, fallback_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        n_cameras=C,
+        opacities=opacities,
+        ray_transforms=bad_ray_transforms,
+        compact_box=True,
+        compact_box_tau2=9.0,
+        compact_box_impl="sweep",
+    )
+
+    torch.testing.assert_close(base_tiles, fallback_tiles)
+    torch.testing.assert_close(base_isect_ids, fallback_isect_ids)
+    torch.testing.assert_close(base_flatten_ids, fallback_flatten_ids)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_isect_compact_box_2dgs_opacity_sensitive(test_data):
+    from gsplat.cuda._wrapper import fully_fused_projection_2dgs, isect_tiles
+
+    Ks = test_data["Ks"]
+    viewmats = test_data["viewmats"]
+    height = test_data["height"]
+    width = test_data["width"]
+    quats = test_data["quats"]
+    scales = test_data["scales"]
+    means = test_data["means"]
+
+    C = viewmats.shape[0]
+    radii, means2d, depths, ray_transforms, _ = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, width, height
+    )
+
+    tile_size = 16
+    tile_width = math.ceil(width / float(tile_size))
+    tile_height = math.ceil(height / float(tile_size))
+
+    high_opacity = torch.full_like(depths, 0.8)
+    low_opacity = torch.full_like(depths, 1.0 / 255.0)
+
+    high_tiles, high_isect_ids, high_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        n_cameras=C,
+        opacities=high_opacity,
+        ray_transforms=ray_transforms,
+        compact_box=True,
+        compact_box_mult=1.0,
+        compact_box_impl="sweep",
+    )
+    low_tiles, low_isect_ids, low_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        n_cameras=C,
+        opacities=low_opacity,
+        ray_transforms=ray_transforms,
+        compact_box=True,
+        compact_box_mult=1.0,
+        compact_box_impl="sweep",
+    )
+
+    assert low_tiles.sum() <= high_tiles.sum()
+    assert low_isect_ids.numel() <= high_isect_ids.numel()
+    assert low_flatten_ids.numel() <= high_flatten_ids.numel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_rasterization_2dgs_compact_box_api(test_data):
+    from gsplat.rendering import rasterization_2dgs
+
+    means = test_data["means"]
+    quats = test_data["quats"]
+    scales = test_data["scales"]
+    opacities = test_data["opacities"].squeeze(0)
+    colors = test_data["colors"].squeeze(0)
+    viewmats = test_data["viewmats"]
+    Ks = test_data["Ks"]
+    width = test_data["width"]
+    height = test_data["height"]
+
+    _, _, _, _, _, _, meta_base = rasterization_2dgs(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        viewmats,
+        Ks,
+        width,
+        height,
+        compact_box=False,
+    )
+    _, _, _, _, _, _, meta_cb = rasterization_2dgs(
+        means,
+        quats,
+        scales,
+        opacities,
+        colors,
+        viewmats,
+        Ks,
+        width,
+        height,
+        compact_box=True,
+        compact_box_mult=1.0,
+        compact_box_impl="sweep",
+    )
+
+    assert meta_cb["isect_ids"].numel() <= meta_base["isect_ids"].numel()
+
+
 if __name__ == "__main__":
     test_projection_2dgs(test_data())
     test_rasterize_to_pixels_2dgs(test_data())
     test_fully_fused_projection_packed_2dgs(test_data())
+    test_isect_compact_box_2dgs(test_data())
+    test_isect_compact_box_2dgs_invalid_ray_fallback(test_data())
+    test_isect_compact_box_2dgs_opacity_sensitive(test_data())
+    test_rasterization_2dgs_compact_box_api(test_data())
     print("All tests passed.")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -506,6 +506,20 @@ def test_isect_compact_box(test_data):
         conics=conics,
         compact_box=True,
         compact_box_tau2=1e9,
+        compact_box_impl="rect_min",
+    )
+    loose_sweep_tiles, loose_sweep_isect_ids, loose_sweep_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        opacities=opacities,
+        conics=conics,
+        compact_box=True,
+        compact_box_tau2=1e9,
+        compact_box_impl="sweep",
     )
     tight_tiles, tight_isect_ids, tight_flatten_ids = isect_tiles(
         means2d,
@@ -518,11 +532,15 @@ def test_isect_compact_box(test_data):
         conics=conics,
         compact_box=True,
         compact_box_tau2=0.0,
+        compact_box_impl="rect_min",
     )
 
     torch.testing.assert_close(base_tiles, loose_tiles)
     torch.testing.assert_close(base_isect_ids, loose_isect_ids)
     torch.testing.assert_close(base_flatten_ids, loose_flatten_ids)
+    torch.testing.assert_close(base_tiles, loose_sweep_tiles)
+    torch.testing.assert_close(base_isect_ids, loose_sweep_isect_ids)
+    torch.testing.assert_close(base_flatten_ids, loose_sweep_flatten_ids)
     assert tight_tiles.sum() <= base_tiles.sum()
     assert tight_isect_ids.numel() <= base_isect_ids.numel()
     assert tight_flatten_ids.numel() <= base_flatten_ids.numel()
@@ -560,6 +578,7 @@ def test_isect_compact_box_opacity_sensitive(test_data):
         conics=conics,
         compact_box=True,
         compact_box_mult=1.0,
+        compact_box_impl="sweep",
     )
     low_tiles, low_isect_ids, low_flatten_ids = isect_tiles(
         means2d,
@@ -572,6 +591,7 @@ def test_isect_compact_box_opacity_sensitive(test_data):
         conics=conics,
         compact_box=True,
         compact_box_mult=1.0,
+        compact_box_impl="sweep",
     )
 
     assert low_tiles.sum() <= high_tiles.sum()
@@ -613,6 +633,7 @@ def test_isect_compact_box_invalid_conic_skip(test_data):
         conics=valid_conics,
         compact_box=True,
         compact_box_mult=1.0,
+        compact_box_impl="sweep",
     )
     invalid_tiles, invalid_isect_ids, invalid_flatten_ids = isect_tiles(
         means2d,
@@ -625,6 +646,7 @@ def test_isect_compact_box_invalid_conic_skip(test_data):
         conics=invalid_conics,
         compact_box=True,
         compact_box_mult=1.0,
+        compact_box_impl="sweep",
     )
 
     assert torch.count_nonzero(invalid_tiles[0]).item() == 0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -473,6 +473,59 @@ def test_isect(test_data):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_isect_compact_box(test_data):
+    from gsplat.cuda._wrapper import isect_tiles
+
+    torch.manual_seed(0)
+
+    C, N = 2, 1024
+    width, height = 64, 48
+    tile_size = 16
+    tile_width = math.ceil(width / tile_size)
+    tile_height = math.ceil(height / tile_size)
+
+    means2d = torch.randn(C, N, 2, device=device) * width
+    radii = torch.randint(0, width, (C, N), device=device, dtype=torch.int32)
+    depths = torch.rand(C, N, device=device)
+    conics = torch.zeros(C, N, 3, device=device)
+    conics[..., 0] = 1.0
+    conics[..., 2] = 1.0
+
+    base_tiles, base_isect_ids, base_flatten_ids = isect_tiles(
+        means2d, radii, depths, tile_size, tile_width, tile_height
+    )
+    loose_tiles, loose_isect_ids, loose_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        conics=conics,
+        compact_box=True,
+        compact_box_tau2=1e9,
+    )
+    tight_tiles, tight_isect_ids, tight_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        conics=conics,
+        compact_box=True,
+        compact_box_tau2=0.0,
+    )
+
+    torch.testing.assert_close(base_tiles, loose_tiles)
+    torch.testing.assert_close(base_isect_ids, loose_isect_ids)
+    torch.testing.assert_close(base_flatten_ids, loose_flatten_ids)
+    assert tight_tiles.sum() <= base_tiles.sum()
+    assert tight_isect_ids.numel() <= base_isect_ids.numel()
+    assert tight_flatten_ids.numel() <= base_flatten_ids.numel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 @pytest.mark.parametrize("channels", [3, 32, 128])
 def test_rasterize_to_pixels(test_data, channels: int):
     from gsplat.cuda._torch_impl import _rasterize_to_pixels

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -487,6 +487,7 @@ def test_isect_compact_box(test_data):
     means2d = torch.randn(C, N, 2, device=device) * width
     radii = torch.randint(0, width, (C, N), device=device, dtype=torch.int32)
     depths = torch.rand(C, N, device=device)
+    opacities = torch.full((C, N), 0.8, device=device)
     conics = torch.zeros(C, N, 3, device=device)
     conics[..., 0] = 1.0
     conics[..., 2] = 1.0
@@ -501,6 +502,7 @@ def test_isect_compact_box(test_data):
         tile_size,
         tile_width,
         tile_height,
+        opacities=opacities,
         conics=conics,
         compact_box=True,
         compact_box_tau2=1e9,
@@ -512,6 +514,7 @@ def test_isect_compact_box(test_data):
         tile_size,
         tile_width,
         tile_height,
+        opacities=opacities,
         conics=conics,
         compact_box=True,
         compact_box_tau2=0.0,
@@ -523,6 +526,111 @@ def test_isect_compact_box(test_data):
     assert tight_tiles.sum() <= base_tiles.sum()
     assert tight_isect_ids.numel() <= base_isect_ids.numel()
     assert tight_flatten_ids.numel() <= base_flatten_ids.numel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_isect_compact_box_opacity_sensitive(test_data):
+    from gsplat.cuda._wrapper import isect_tiles
+
+    torch.manual_seed(1)
+
+    C, N = 2, 1024
+    width, height = 64, 48
+    tile_size = 16
+    tile_width = math.ceil(width / tile_size)
+    tile_height = math.ceil(height / tile_size)
+
+    means2d = torch.randn(C, N, 2, device=device) * width
+    radii = torch.randint(1, width, (C, N), device=device, dtype=torch.int32)
+    depths = torch.rand(C, N, device=device)
+    conics = torch.zeros(C, N, 3, device=device)
+    conics[..., 0] = 1.0
+    conics[..., 2] = 1.0
+    high_opacity = torch.full((C, N), 0.8, device=device)
+    low_opacity = torch.full((C, N), 1.0 / 255.0, device=device)
+
+    high_tiles, high_isect_ids, high_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        opacities=high_opacity,
+        conics=conics,
+        compact_box=True,
+        compact_box_mult=1.0,
+    )
+    low_tiles, low_isect_ids, low_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        opacities=low_opacity,
+        conics=conics,
+        compact_box=True,
+        compact_box_mult=1.0,
+    )
+
+    assert low_tiles.sum() <= high_tiles.sum()
+    assert low_isect_ids.numel() <= high_isect_ids.numel()
+    assert low_flatten_ids.numel() <= high_flatten_ids.numel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_isect_compact_box_invalid_conic_skip(test_data):
+    from gsplat.cuda._wrapper import isect_tiles
+
+    torch.manual_seed(2)
+
+    C, N = 2, 256
+    width, height = 64, 48
+    tile_size = 16
+    tile_width = math.ceil(width / tile_size)
+    tile_height = math.ceil(height / tile_size)
+
+    means2d = torch.randn(C, N, 2, device=device) * width
+    radii = torch.randint(1, width, (C, N), device=device, dtype=torch.int32)
+    depths = torch.rand(C, N, device=device)
+    opacities = torch.full((C, N), 0.8, device=device)
+
+    valid_conics = torch.zeros(C, N, 3, device=device)
+    valid_conics[..., 0] = 1.0
+    valid_conics[..., 2] = 1.0
+    invalid_conics = valid_conics.clone()
+    invalid_conics[0, :, 0] = -1.0
+
+    valid_tiles, valid_isect_ids, valid_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        opacities=opacities,
+        conics=valid_conics,
+        compact_box=True,
+        compact_box_mult=1.0,
+    )
+    invalid_tiles, invalid_isect_ids, invalid_flatten_ids = isect_tiles(
+        means2d,
+        radii,
+        depths,
+        tile_size,
+        tile_width,
+        tile_height,
+        opacities=opacities,
+        conics=invalid_conics,
+        compact_box=True,
+        compact_box_mult=1.0,
+    )
+
+    assert torch.count_nonzero(invalid_tiles[0]).item() == 0
+    assert invalid_tiles.sum() <= valid_tiles.sum()
+    assert invalid_isect_ids.numel() <= valid_isect_ids.numel()
+    assert invalid_flatten_ids.numel() <= valid_flatten_ids.numel()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")


### PR DESCRIPTION
## Summary
- add a new Compact Box implementation mode `compact_box_impl` with two options:
  - `rect_min`: per-tile rectangle-min Mahalanobis test (reference path)
  - `sweep`: slice/span traversal path (new fast path, default)
- keep FastGS-aligned CB threshold semantics:
  - if `compact_box_tau2` is unset, use per-Gaussian `tau2_i = compact_box_mult * 2 * log(opacity_i * 255)`
  - hard-skip invalid conics (`q00<=0`, `q11<=0`, or `q00*q11-q01*q01<=0`) and non-positive tau for 3DGS
- add Compact Box support to **2DGS** tile mapping:
  - derive a CB conic approximation from `ray_transforms` in `isect_tiles`
  - reuse both `rect_min` and `sweep` traversal paths
  - if 2DGS conic derivation is invalid, conservatively fallback to coarse radius-box traversal
- thread CB settings through Python/C++/CUDA bindings while keeping two-pass count/emit consistency in `isect_tiles`
- update docs and tooling:
  - `docs/COMPACT_BOX.md` + `docs/COMPACT_BOX_2DGS.md`
  - `examples/benchmark_compact_box.py` and new `examples/benchmark_compact_box_2dgs.py`
  - `examples/simple_trainer_2dgs.py` gets CB flags (`compact_box`, `compact_box_mult`, `compact_box_tau2`, `compact_box_impl`)
- add/update tests:
  - `tests/test_basic.py` for 3DGS CB behavior
  - `tests/test_2dgs.py` for 2DGS CB equivalence/monotonicity/fallback/API checks

## Performance Notes
### 3DGS (synthetic, 120000 gaussians, 2 cameras, 1280x720)
- `rect_min` CB: ~`1.55x` speedup vs baseline
- `sweep` CB: ~`1.75x` speedup vs baseline
- `n_isects` reduction remains ~`44-45%`
- image diff is negligible (often zero in benchmark runs)

### 2DGS (synthetic stress, 120000 gaussians, 2 cameras, 1280x720)
- baseline: `14.279 ms`, `13,068,960` isects
- `mult=0.8`: `6.385 ms` (`2.236x`), `-57.88%` isects, `PSNR=54.20`
- `mult=1.0`: `6.620 ms` (`2.157x`), `-51.37%` isects, `PSNR=60.44`
- `mult=1.2`: `7.066 ms` (`2.021x`), `-46.60%` isects, `PSNR=63.65`

### 2DGS (3 random scenes aggregate)
- `mult=0.8`: mean `1.401x` speedup, `-45.90%` isects, PSNR `55.03`, SSIM `0.999511`, LPIPS `0.000952`
- `mult=1.0`: mean `1.313x` speedup, `-38.92%` isects, PSNR `60.59`, SSIM `0.999834`, LPIPS `0.000382`
- `mult=1.2`: mean `1.238x` speedup, `-33.80%` isects, PSNR `65.29`, SSIM `0.999921`, LPIPS `0.000179`

## Recommended Defaults
- keep default/safe profile as `compact_box_mult=1.0` with `compact_box_impl="sweep"`
- use `compact_box_mult=0.8` for more aggressive speed
- use `compact_box_mult=1.2` for more conservative visual parity

## API Changes
`rasterization(...)` accepts:
- `compact_box_impl: Literal["rect_min", "sweep"] = "sweep"`

`rasterization_2dgs(...)` accepts:
- `compact_box: bool = False`
- `compact_box_mult: float = 1.0`
- `compact_box_tau2: Optional[float] = None`
- `compact_box_impl: Literal["rect_min", "sweep"] = "sweep"`

`isect_tiles(...)` wrapper accepts:
- `compact_box_impl: Literal["rect_min", "sweep"] = "sweep"`
- optional `ray_transforms` for 2DGS CB derivation (existing 3DGS callsites remain compatible)

## Validation
- `python -m py_compile gsplat/cuda/_wrapper.py gsplat/rendering.py tests/test_basic.py tests/test_2dgs.py examples/benchmark_compact_box.py examples/benchmark_compact_box_2dgs.py examples/simple_trainer_2dgs.py`
- `PYTHONPATH=. python examples/benchmark_compact_box.py --compact-box-impl rect_min`
- `PYTHONPATH=. python examples/benchmark_compact_box.py --compact-box-impl sweep`
- `PYTHONPATH=. python examples/benchmark_compact_box_2dgs.py --sweep-mults 0.8 1.0 1.2`