### PR TITLE
Add packed camera gradients

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -245,6 +245,14 @@ def fully_fused_projection(
         which will be converted to covariances internally in a fused CUDA kernel. Either `covars` or
         {`quats`, `scales`} should be provided.
 
+    .. warning::
+
+        The backward pass computes only the existing partial gradient with respect to
+        camera intrinsics `Ks`. It uses the projected-mean VJP and pinhole-style
+        `fx`, `fy`, `cx`, and `cy` terms. Gradients through projected covariance,
+        conic, and compensation paths are not included, and non-pinhole camera
+        models reuse this partial intrinsic gradient.
+
     Args:
         means: Gaussian means. [N, 3]
         covars: Gaussian covariances (flattened upper triangle). [N, 6] Optional.
@@ -849,6 +857,10 @@ class _WorldToCam(torch.autograd.Function):
         return v_means, v_covars, v_viewmats
 
 
+# NOTE: 3DGS `Ks` gradients intentionally mirror the historical unpacked path.
+# They are partial: only projected-mean VJPs are propagated through pinhole-style
+# fx/fy/cx/cy terms. Covariance, conic, compensation, and camera-model-specific
+# intrinsic derivative paths are not included here.
 def _grad_K_reference(
     *,
     means: Tensor,
@@ -918,6 +930,52 @@ def _grad_K_direct(
     grad_K[:, 1, 1] = (v_v * means3d_cam[..., 1] / z).sum(dim=1)
     grad_K[:, 0, 2] = v_u.sum(dim=1)
     grad_K[:, 1, 2] = v_v.sum(dim=1)
+    return grad_K
+
+
+def _grad_K_packed_direct(
+    *,
+    means: Tensor,
+    viewmats: Tensor,
+    camera_ids: Tensor,
+    gaussian_ids: Tensor,
+    v_means2d: Tensor,
+    width: int,
+    height: int,
+) -> Tensor:
+    means_i = means[gaussian_ids]
+    viewmats_i = viewmats[camera_ids]
+    means3d_cam = torch.bmm(
+        means_i[:, None, :], viewmats_i[:, :3, :3].transpose(1, 2)
+    ).squeeze(1) + viewmats_i[:, :3, 3]
+    z = means3d_cam[:, 2] + 1e-4
+    v_u = v_means2d[:, 0] * (width * 0.5)
+    v_v = v_means2d[:, 1] * (height * 0.5)
+
+    grad_k_entries = torch.stack(
+        [
+            v_u * means3d_cam[:, 0] / z,
+            v_v * means3d_cam[:, 1] / z,
+            v_u,
+            v_v,
+        ],
+        dim=-1,
+    ).to(torch.float32)
+    grad_k = torch.zeros(
+        viewmats.shape[0], 4, device=viewmats.device, dtype=grad_k_entries.dtype
+    )
+    for cid in range(viewmats.shape[0]):
+        mask = camera_ids == cid
+        if bool(mask.any()):
+            grad_k[cid] = grad_k_entries[mask].sum(dim=0)
+
+    grad_K = torch.zeros(
+        viewmats.shape[0], 3, 3, device=viewmats.device, dtype=torch.float32
+    )
+    grad_K[:, 0, 0] = grad_k[:, 0]
+    grad_K[:, 1, 1] = grad_k[:, 1]
+    grad_K[:, 0, 2] = grad_k[:, 2]
+    grad_K[:, 1, 2] = grad_k[:, 3]
     return grad_K
 
 
@@ -1437,6 +1495,18 @@ class _FullyFusedProjectionPacked(torch.autograd.Function):
                 )
         if not ctx.needs_input_grad[4]:
             v_viewmats = None
+        if not ctx.needs_input_grad[5]:
+            grad_K = None
+        else:
+            grad_K = _grad_K_packed_direct(
+                means=means,
+                viewmats=viewmats,
+                camera_ids=camera_ids,
+                gaussian_ids=gaussian_ids,
+                v_means2d=v_means2d,
+                width=width,
+                height=height,
+            )
 
         return (
             v_means,
@@ -1444,7 +1514,7 @@ class _FullyFusedProjectionPacked(torch.autograd.Function):
             v_quats,
             v_scales,
             v_viewmats,
-            None,
+            grad_K,
             None,
             None,
             None,
@@ -1491,6 +1561,10 @@ class _SphericalHarmonics(torch.autograd.Function):
 
 
 ###### 2DGS ######
+# NOTE: 2DGS camera gradients intentionally mirror the historical unpacked path.
+# `Ks` and Python-recomputed `viewmats` gradients use only the direct upstream
+# `v_ray_transforms`. The local VJP terms that CUDA folds in from means2d,
+# depths, and normals are not included in these camera gradients.
 def _grad_K_2dgs_reference(
     *,
     Ks: Tensor,
@@ -1556,6 +1630,72 @@ def _grad_K_2dgs_direct(
     grad_K[:, 0, 2] = grad_k[:, 2]
     grad_K[:, 1, 2] = grad_k[:, 3]
     return grad_K
+
+
+def _grad_K_2dgs_packed_direct(
+    *,
+    Ks: Tensor,
+    camera_ids: Tensor,
+    ray_transforms: Tensor,
+    v_ray_transforms: Tensor,
+) -> Tensor:
+    T = Ks[camera_ids].inverse() @ ray_transforms
+
+    grad_k = torch.stack(
+        [
+            (T[:, 0, :] * v_ray_transforms[:, 0, :]).sum(dim=-1),
+            (T[:, 1, :] * v_ray_transforms[:, 1, :]).sum(dim=-1),
+            (T[:, 2, :] * v_ray_transforms[:, 0, :]).sum(dim=-1),
+            (T[:, 2, :] * v_ray_transforms[:, 1, :]).sum(dim=-1),
+        ],
+        dim=-1,
+    )
+    grad_k_accum = torch.zeros(Ks.shape[0], 4, device=Ks.device, dtype=Ks.dtype)
+    for cid in range(Ks.shape[0]):
+        mask = camera_ids == cid
+        if bool(mask.any()):
+            grad_k_accum[cid] = grad_k[mask].sum(dim=0)
+
+    grad_K = torch.zeros_like(Ks)
+    grad_K[:, 0, 0] = grad_k_accum[:, 0]
+    grad_K[:, 1, 1] = grad_k_accum[:, 1]
+    grad_K[:, 0, 2] = grad_k_accum[:, 2]
+    grad_K[:, 1, 2] = grad_k_accum[:, 3]
+    return grad_K
+
+
+@torch.no_grad()
+def _v_viewmats_2dgs_packed(
+    *,
+    means: Tensor,
+    quats: Tensor,
+    scales: Tensor,
+    viewmats: Tensor,
+    Ks: Tensor,
+    camera_ids: Tensor,
+    gaussian_ids: Tensor,
+    v_ray_transforms: Tensor,
+) -> Tensor:
+    C = Ks.shape[0]
+    N = means.shape[0]
+    Kt4 = torch.zeros(C, 4, 3, device=means.device, dtype=means.dtype)
+    Kt4[:, :3, :3] = Ks.transpose(-1, -2)
+
+    RS_wl = _quat_scale_to_matrix(quats, scales)
+    RS_t = torch.zeros(N, 3, 4, device=means.device, dtype=means.dtype)
+    RS_t[:, :2, :3] = RS_wl[:, :, :2].transpose(-1, -2)
+    RS_t[:, 2, :3] = means
+    RS_t[:, 2, 3] = 1
+
+    v_viewmats_i = torch.einsum(
+        "nab,nbd,nde->nae", Kt4[camera_ids], v_ray_transforms, RS_t[gaussian_ids]
+    )
+    v_viewmats = torch.zeros_like(viewmats)
+    for cid in range(viewmats.shape[0]):
+        mask = camera_ids == cid
+        if bool(mask.any()):
+            v_viewmats[cid] = v_viewmats_i[mask].sum(dim=0)
+    return v_viewmats
 
 
 def _grad_K_2dgs_visible_single_camera(
@@ -1649,6 +1789,13 @@ def fully_fused_projection_2dgs(
 
     This function prepares ray-splat intersection matrices, computes
     per splat bounding box and 2D means in image space.
+
+    .. warning::
+
+        The backward pass computes only the existing partial camera gradients for
+        `Ks` and `viewmats`. They use the direct `ray_transforms` VJP only; VJP
+        terms folded inside the CUDA projection backward from `means2d`,
+        `depths`, and `normals` are not included in these camera gradients.
 
     Args:
         means: Gaussian means. [N, 3]
@@ -2054,7 +2201,7 @@ class _FullyFusedProjectionPacked2DGS(torch.autograd.Function):
             v_depths.contiguous(),
             v_ray_transforms.contiguous(),
             v_normals.contiguous(),
-            ctx.needs_input_grad[4],  # viewmats_requires_grad
+            ctx.needs_input_grad[3],  # viewmats_requires_grad
             sparse_grad,
         )
 
@@ -2092,15 +2239,45 @@ class _FullyFusedProjectionPacked2DGS(torch.autograd.Function):
                     size=scales.size(),  # [N, 3]
                     is_coalesced=len(viewmats) == 1,
                 )
-        if not ctx.needs_input_grad[4]:
+        if not ctx.needs_input_grad[3]:
             v_viewmats = None
+        else:
+            v_viewmats = _v_viewmats_2dgs_packed(
+                means=means,
+                quats=quats,
+                scales=scales,
+                viewmats=viewmats,
+                Ks=Ks,
+                camera_ids=camera_ids,
+                gaussian_ids=gaussian_ids,
+                v_ray_transforms=v_ray_transforms,
+            )
+        if not ctx.needs_input_grad[4]:
+            grad_K = None
+        else:
+            grad_K = _grad_K_2dgs_packed_direct(
+                Ks=Ks,
+                camera_ids=camera_ids,
+                ray_transforms=ray_transforms,
+                v_ray_transforms=v_ray_transforms,
+            )
+
+        if isinstance(v_viewmats, torch.Tensor):
+            v_viewmats = torch.nan_to_num(
+                v_viewmats,
+                nan=0.0,
+                posinf=0.0,
+                neginf=0.0,
+            )
+        if isinstance(grad_K, torch.Tensor):
+            grad_K = torch.nan_to_num(grad_K, nan=0.0, posinf=0.0, neginf=0.0)
 
         return (
             v_means,
             v_quats,
             v_scales,
             v_viewmats,
-            None,
+            grad_K,
             None,
             None,
             None,

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1186,7 +1186,6 @@ class _FullyFusedProjection(torch.autograd.Function):
             None,
             None,
             None,
-            None,
         )
 
 
@@ -2278,8 +2277,6 @@ class _FullyFusedProjectionPacked2DGS(torch.autograd.Function):
             v_scales,
             v_viewmats,
             grad_K,
-            None,
-            None,
             None,
             None,
             None,

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1638,7 +1638,7 @@ def _grad_K_2dgs_packed_direct(
     ray_transforms: Tensor,
     v_ray_transforms: Tensor,
 ) -> Tensor:
-    T = Ks[camera_ids].inverse() @ ray_transforms
+    T = Ks.inverse()[camera_ids] @ ray_transforms
 
     grad_k = torch.stack(
         [
@@ -1650,10 +1650,7 @@ def _grad_K_2dgs_packed_direct(
         dim=-1,
     )
     grad_k_accum = torch.zeros(Ks.shape[0], 4, device=Ks.device, dtype=Ks.dtype)
-    for cid in range(Ks.shape[0]):
-        mask = camera_ids == cid
-        if bool(mask.any()):
-            grad_k_accum[cid] = grad_k[mask].sum(dim=0)
+    grad_k_accum.index_add_(0, camera_ids, grad_k)
 
     grad_K = torch.zeros_like(Ks)
     grad_K[:, 0, 0] = grad_k_accum[:, 0]
@@ -1686,15 +1683,14 @@ def _v_viewmats_2dgs_packed(
     RS_t[:, 2, :3] = means
     RS_t[:, 2, 3] = 1
 
-    v_viewmats_i = torch.einsum(
-        "nab,nbd,nde->nae", Kt4[camera_ids], v_ray_transforms, RS_t[gaussian_ids]
+    v_viewmats_i = torch.bmm(
+        torch.bmm(Kt4[camera_ids], v_ray_transforms), RS_t[gaussian_ids]
     )
-    v_viewmats = torch.zeros_like(viewmats)
-    for cid in range(viewmats.shape[0]):
-        mask = camera_ids == cid
-        if bool(mask.any()):
-            v_viewmats[cid] = v_viewmats_i[mask].sum(dim=0)
-    return v_viewmats
+    v_viewmats = torch.zeros(
+        viewmats.shape[0], 16, device=viewmats.device, dtype=viewmats.dtype
+    )
+    v_viewmats.index_add_(0, camera_ids, v_viewmats_i.reshape(-1, 16))
+    return v_viewmats.reshape_as(viewmats)
 
 
 def _grad_K_2dgs_visible_single_camera(

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -962,12 +962,10 @@ def _grad_K_packed_direct(
         dim=-1,
     ).to(torch.float32)
     grad_k = torch.zeros(
-        viewmats.shape[0], 4, device=viewmats.device, dtype=grad_k_entries.dtype
+        viewmats.shape[0], 4, device=viewmats.device, dtype=torch.float64
     )
-    for cid in range(viewmats.shape[0]):
-        mask = camera_ids == cid
-        if bool(mask.any()):
-            grad_k[cid] = grad_k_entries[mask].sum(dim=0)
+    grad_k.index_add_(0, camera_ids, grad_k_entries.to(torch.float64))
+    grad_k = grad_k.to(torch.float32)
 
     grad_K = torch.zeros(
         viewmats.shape[0], 3, 3, device=viewmats.device, dtype=torch.float32

--- a/gsplat/cuda/csrc/fully_fused_projection_packed_2dgs_fwd.cu
+++ b/gsplat/cuda/csrc/fully_fused_projection_packed_2dgs_fwd.cu
@@ -62,6 +62,7 @@ __global__ void fully_fused_projection_packed_fwd_2dgs_kernel(
         // shift pointers to the current camera and gaussian
         means += col_idx * 3;
         viewmats += row_idx * 16;
+        Ks += row_idx * 9;
 
         // glm is column-major but input is row-major
         R = mat3<T>(

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -137,7 +137,11 @@ def rasterization(
         which is shown to be more effective for splitting Gaussians during training.
 
     .. warning::
-        This function is currently not differentiable w.r.t. the camera intrinsics `Ks`.
+        Gradients with respect to camera intrinsics `Ks` are partial. They match
+        the projection helper behavior for packed and unpacked modes, but only
+        include the projected-mean VJP with pinhole-style `fx`, `fy`, `cx`, and
+        `cy` terms. Covariance, conic, and compensation contributions are not
+        included, and `ortho`/`fisheye` reuse the same partial intrinsic gradient.
 
     Args:
         means: The 3D centers of the Gaussians. [N, 3]
@@ -1058,7 +1062,11 @@ def rasterization_2dgs(
     This function supports a handful of features, similar to the :func:`rasterization` function.
 
     .. warning::
-        This function is currently not differentiable w.r.t. the camera intrinsics `Ks`.
+        Gradients with respect to camera intrinsics `Ks` and camera transforms
+        `viewmats` are partial. They match packed and unpacked projection helper
+        behavior, but use only direct `ray_transforms` VJPs; VJP terms folded
+        inside the CUDA 2DGS projection backward from `means2d`, `depths`, and
+        `normals` are not included in these camera gradients.
 
     Args:
         means: The 3D centers of the Gaussians. [N, 3]
@@ -1165,8 +1173,6 @@ def rasterization_2dgs(
         'gradient_2dgs'])
 
     """
-    assert packed is not True, "packed mode is not supported in 2DGS"
-
     N = means.shape[0]
     C = viewmats.shape[0]
     assert means.shape == (N, 3), means.shape

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -40,7 +40,7 @@ def rasterization(
     radius_clip: float = 0.0,
     eps2d: float = 0.3,
     sh_degree: Optional[int] = None,
-    packed: bool = True,
+    packed: bool = False,
     tile_size: int = 16,
     compact_box: bool = False,
     compact_box_mult: float = 1.0,
@@ -1090,7 +1090,7 @@ def rasterization_2dgs(
             number of bands. If set, the `colors` should be [(C,) N, K, 3] SH coefficients,
             else the `colors` should [(C,) N, D] post-activation color values. Default is None.
         packed: Whether to use packed mode which is more memory efficient but might or
-            might not be as fast. Default is True.
+            might not be as fast. Default is False.
         tile_size: The size of the tiles for rasterization. Default is 16.
             (Note: other values are not tested)
         compact_box: Enable Compact Box tile pruning based on a 2DGS conic

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -102,6 +102,95 @@ def test_grad_K_2dgs_dispatcher_uses_requested_implementation(monkeypatch):
     torch.testing.assert_close(grad_K, expected)
 
 
+def test_grad_K_2dgs_packed_direct_inverts_each_camera_once(monkeypatch):
+    from gsplat.cuda._wrapper import _grad_K_2dgs_packed_direct
+
+    Ks, ray_transforms_dense, v_ray_transforms_dense, _ = _make_grad_K_2dgs_inputs(
+        c=3, n=4
+    )
+    camera_ids = torch.tensor([0, 1, 1, 2, 0, 2], dtype=torch.int64)
+    gaussian_ids = torch.tensor([0, 1, 3, 2, 2, 0], dtype=torch.int64)
+    ray_transforms = ray_transforms_dense[camera_ids, gaussian_ids]
+    v_ray_transforms = v_ray_transforms_dense[camera_ids, gaussian_ids]
+    original_inverse = torch.Tensor.inverse
+    inverse_shapes = []
+
+    def _record_inverse(tensor):
+        inverse_shapes.append(tuple(tensor.shape))
+        return original_inverse(tensor)
+
+    monkeypatch.setattr(torch.Tensor, "inverse", _record_inverse)
+
+    grad_K = _grad_K_2dgs_packed_direct(
+        Ks=Ks,
+        camera_ids=camera_ids,
+        ray_transforms=ray_transforms,
+        v_ray_transforms=v_ray_transforms,
+    )
+
+    assert inverse_shapes == [(Ks.shape[0], 3, 3)]
+    assert grad_K.shape == Ks.shape
+
+
+def test_grad_K_2dgs_packed_direct_avoids_tensor_bool_accumulation(monkeypatch):
+    from gsplat.cuda._wrapper import _grad_K_2dgs_packed_direct
+
+    Ks, ray_transforms_dense, v_ray_transforms_dense, _ = _make_grad_K_2dgs_inputs(
+        c=3, n=4
+    )
+    camera_ids = torch.tensor([0, 1, 1, 2, 0, 2], dtype=torch.int64)
+    gaussian_ids = torch.tensor([0, 1, 3, 2, 2, 0], dtype=torch.int64)
+    ray_transforms = ray_transforms_dense[camera_ids, gaussian_ids]
+    v_ray_transforms = v_ray_transforms_dense[camera_ids, gaussian_ids]
+
+    def _forbid_tensor_bool(_tensor):
+        raise AssertionError("packed accumulation should not convert tensors to bool")
+
+    monkeypatch.setattr(torch.Tensor, "__bool__", _forbid_tensor_bool)
+
+    grad_K = _grad_K_2dgs_packed_direct(
+        Ks=Ks,
+        camera_ids=camera_ids,
+        ray_transforms=ray_transforms,
+        v_ray_transforms=v_ray_transforms,
+    )
+
+    assert grad_K.shape == Ks.shape
+
+
+def test_v_viewmats_2dgs_packed_avoids_tensor_bool_accumulation(monkeypatch):
+    from gsplat.cuda._wrapper import _v_viewmats_2dgs_packed
+
+    torch.manual_seed(42)
+    C, N = 3, 5
+    camera_ids = torch.tensor([0, 1, 1, 2, 0, 2], dtype=torch.int64)
+    gaussian_ids = torch.tensor([0, 1, 3, 2, 4, 0], dtype=torch.int64)
+    means = torch.randn(N, 3)
+    quats = torch.randn(N, 4)
+    scales = torch.rand(N, 3) + 0.1
+    viewmats = torch.eye(4).repeat(C, 1, 1)
+    Ks = torch.eye(3).repeat(C, 1, 1)
+    v_ray_transforms = torch.randn(camera_ids.shape[0], 3, 3)
+
+    def _forbid_tensor_bool(_tensor):
+        raise AssertionError("packed accumulation should not convert tensors to bool")
+
+    monkeypatch.setattr(torch.Tensor, "__bool__", _forbid_tensor_bool)
+
+    v_viewmats = _v_viewmats_2dgs_packed(
+        means=means,
+        quats=quats,
+        scales=scales,
+        viewmats=viewmats,
+        Ks=Ks,
+        camera_ids=camera_ids,
+        gaussian_ids=gaussian_ids,
+        v_ray_transforms=v_ray_transforms,
+    )
+
+    assert v_viewmats.shape == viewmats.shape
+
+
 def test_fully_fused_projection_packed_2dgs_backward_return_arity(monkeypatch):
     import gsplat.cuda._wrapper as wrapper
 

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -135,6 +135,16 @@ def test_data():
     }
 
 
+def _make_two_camera_inputs(test_data):
+    viewmats = test_data["viewmats"].repeat(2, 1, 1).clone()
+    Ks = test_data["Ks"].repeat(2, 1, 1).clone()
+    Ks[1, 0, 0] *= 0.75
+    Ks[1, 1, 1] *= 1.25
+    Ks[1, 0, 2] += 17.0
+    Ks[1, 1, 2] -= 11.0
+    return viewmats, Ks
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
 def test_projection_2dgs(test_data):
     from gsplat.cuda._torch_impl_2dgs import _fully_fused_projection_2dgs
@@ -222,17 +232,14 @@ def test_fully_fused_projection_packed_2dgs(
 
     torch.manual_seed(42)
 
-    Ks = test_data["Ks"]
-    viewmats = test_data["viewmats"]
+    viewmats, Ks = _make_two_camera_inputs(test_data)
     height = test_data["height"]
     width = test_data["width"]
-    quats = test_data["quats"]
-    scales = test_data["scales"]
-    means = test_data["means"]
-    viewmats.requires_grad = False
-    quats.requires_grad = True
-    scales.requires_grad = True
-    means.requires_grad = True
+    quats = test_data["quats"].detach().clone().requires_grad_(True)
+    scales = test_data["scales"].detach().clone().requires_grad_(True)
+    means = test_data["means"].detach().clone().requires_grad_(True)
+    viewmats = viewmats.detach().clone().requires_grad_(True)
+    Ks = Ks.detach().clone().requires_grad_(True)
 
     (
         camera_ids,
@@ -295,20 +302,20 @@ def test_fully_fused_projection_packed_2dgs(
     v_depths = torch.randn_like(_depths) * sel
     v_ray_transforms = torch.randn_like(_ray_transforms) * sel[..., None, None]
     v_normals = torch.randn_like(_normals) * sel[..., None]
-    _v_quats, _v_scales, _v_means = torch.autograd.grad(
+    _v_viewmats, _v_Ks, _v_quats, _v_scales, _v_means = torch.autograd.grad(
         (_means2d * v_means2d).sum()
         + (_depths * v_depths).sum()
         + (_ray_transforms * v_ray_transforms).sum()
         + (_normals * v_normals).sum(),
-        (quats, scales, means),
+        (viewmats, Ks, quats, scales, means),
         retain_graph=True,
     )
-    v_quats, v_scales, v_means = torch.autograd.grad(
+    v_viewmats, v_Ks, v_quats, v_scales, v_means = torch.autograd.grad(
         (means2d * v_means2d[__radii > 0]).sum()
         + (depths * v_depths[__radii > 0]).sum()
         + (ray_transforms * v_ray_transforms[__radii > 0]).sum()
         + (normals * v_normals[__radii > 0]).sum(),
-        (quats, scales, means),
+        (viewmats, Ks, quats, scales, means),
         retain_graph=True,
     )
     if sparse_grad:
@@ -316,6 +323,8 @@ def test_fully_fused_projection_packed_2dgs(
         v_scales = v_scales.to_dense()
         v_means = v_means.to_dense()
 
+    torch.testing.assert_close(v_viewmats, _v_viewmats, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(v_Ks, _v_Ks, rtol=1e-4, atol=1e-4)
     torch.testing.assert_close(v_scales, _v_scales, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(v_means, _v_means, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(v_quats, _v_quats, rtol=1e-2, atol=1e-2)
@@ -694,6 +703,69 @@ def test_rasterization_2dgs_compact_box_api(test_data):
     )
 
     assert meta_cb["isect_ids"].numel() <= meta_base["isect_ids"].numel()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+@pytest.mark.parametrize("sparse_grad", [False, True])
+def test_rasterization_2dgs_packed_matches_unpacked(test_data, sparse_grad: bool):
+    from gsplat.rendering import rasterization_2dgs
+
+    torch.manual_seed(42)
+
+    base_viewmats, base_Ks = _make_two_camera_inputs(test_data)
+    height = test_data["height"]
+    width = test_data["width"]
+    opacities = test_data["opacities"].squeeze(0)
+    colors = test_data["colors"].squeeze(0)
+
+    def render(packed: bool):
+        means = test_data["means"].detach().clone().requires_grad_(True)
+        quats = test_data["quats"].detach().clone().requires_grad_(True)
+        scales = test_data["scales"].detach().clone().requires_grad_(True)
+        viewmats = base_viewmats.detach().clone().requires_grad_(True)
+        Ks = base_Ks.detach().clone().requires_grad_(True)
+        outputs = rasterization_2dgs(
+            means,
+            quats,
+            scales,
+            opacities,
+            colors,
+            viewmats,
+            Ks,
+            width,
+            height,
+            packed=packed,
+            sparse_grad=sparse_grad if packed else False,
+        )
+        return outputs, viewmats, Ks
+
+    packed_outputs, packed_viewmats, packed_Ks = render(True)
+    unpacked_outputs, unpacked_viewmats, unpacked_Ks = render(False)
+
+    packed_colors, packed_alphas, packed_normals, *_, packed_meta = packed_outputs
+    unpacked_colors, unpacked_alphas, unpacked_normals, *_, unpacked_meta = unpacked_outputs
+
+    torch.testing.assert_close(packed_colors, unpacked_colors, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(packed_alphas, unpacked_alphas, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(packed_normals, unpacked_normals, rtol=1e-4, atol=1e-4)
+    assert packed_meta["camera_ids"] is not None
+    assert packed_meta["gaussian_ids"] is not None
+    assert unpacked_meta["camera_ids"] is None
+    assert unpacked_meta["gaussian_ids"] is None
+
+    packed_loss = packed_colors.sum() + packed_alphas.sum() + packed_normals.sum()
+    unpacked_loss = unpacked_colors.sum() + unpacked_alphas.sum() + unpacked_normals.sum()
+    packed_v_viewmats, packed_v_Ks = torch.autograd.grad(
+        packed_loss, (packed_viewmats, packed_Ks)
+    )
+    unpacked_v_viewmats, unpacked_v_Ks = torch.autograd.grad(
+        unpacked_loss, (unpacked_viewmats, unpacked_Ks)
+    )
+
+    torch.testing.assert_close(
+        packed_v_viewmats, unpacked_v_viewmats, rtol=5e-2, atol=1e-2
+    )
+    torch.testing.assert_close(packed_v_Ks, unpacked_v_Ks, rtol=5e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 
 import pytest
@@ -99,6 +100,89 @@ def test_grad_K_2dgs_dispatcher_uses_requested_implementation(monkeypatch):
     )
 
     torch.testing.assert_close(grad_K, expected)
+
+
+def test_fully_fused_projection_packed_2dgs_backward_return_arity(monkeypatch):
+    import gsplat.cuda._wrapper as wrapper
+
+    class Ctx:
+        pass
+
+    C, N, nnz = 1, 2, 2
+    camera_ids = torch.zeros(nnz, dtype=torch.int64)
+    gaussian_ids = torch.arange(nnz, dtype=torch.int64)
+    means = torch.randn(N, 3)
+    quats = torch.randn(N, 4)
+    scales = torch.randn(N, 3)
+    viewmats = torch.eye(4).repeat(C, 1, 1)
+    Ks = torch.eye(3).repeat(C, 1, 1)
+    ray_transforms = torch.randn(nnz, 3, 3)
+
+    ctx = Ctx()
+    ctx.saved_tensors = (
+        camera_ids,
+        gaussian_ids,
+        means,
+        quats,
+        scales,
+        viewmats,
+        Ks,
+        ray_transforms,
+    )
+    ctx.width = 32
+    ctx.height = 24
+    ctx.sparse_grad = False
+    ctx.needs_input_grad = (
+        True,
+        True,
+        True,
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+
+    def make_lazy_cuda_func(name):
+        assert name == "fully_fused_projection_packed_bwd_2dgs"
+
+        def bwd(*args):
+            return (
+                torch.zeros_like(means),
+                torch.zeros_like(quats),
+                torch.zeros_like(scales),
+                torch.zeros_like(viewmats),
+            )
+
+        return bwd
+
+    monkeypatch.setattr(wrapper, "_make_lazy_cuda_func", make_lazy_cuda_func)
+    monkeypatch.setattr(
+        wrapper, "_v_viewmats_2dgs_packed", lambda **kwargs: torch.zeros_like(viewmats)
+    )
+    monkeypatch.setattr(
+        wrapper, "_grad_K_2dgs_packed_direct", lambda **kwargs: torch.zeros_like(Ks)
+    )
+
+    result = wrapper._FullyFusedProjectionPacked2DGS.backward(
+        ctx,
+        None,
+        None,
+        None,
+        torch.zeros(nnz, 2),
+        torch.zeros(nnz),
+        torch.zeros(nnz, 3, 3),
+        torch.zeros(nnz, 3),
+    )
+    n_forward_inputs = (
+        len(inspect.signature(wrapper._FullyFusedProjectionPacked2DGS.forward).parameters)
+        - 1
+    )
+
+    assert len(result) == n_forward_inputs
 
 
 @pytest.fixture

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -48,6 +48,38 @@ def test_grad_K_direct_matches_reference():
     torch.testing.assert_close(grad_K, expected)
 
 
+def test_grad_K_packed_direct_avoids_tensor_bool_accumulation(monkeypatch):
+    from gsplat.cuda._wrapper import _grad_K_packed_direct
+
+    torch.manual_seed(42)
+    C, N = 3, 7
+    width, height = 320, 240
+    camera_ids = torch.tensor([0, 2, 1, 2, 0, 1], dtype=torch.int64)
+    gaussian_ids = torch.tensor([0, 1, 2, 3, 4, 5], dtype=torch.int64)
+    means = torch.randn(N, 3)
+    viewmats = torch.eye(4).repeat(C, 1, 1)
+    viewmats[:, :3, :3] += torch.randn(C, 3, 3) * 0.01
+    viewmats[:, :3, 3] = torch.randn(C, 3)
+    v_means2d = torch.randn(camera_ids.shape[0], 2)
+
+    def _forbid_tensor_bool(_tensor):
+        raise AssertionError("packed accumulation should not convert tensors to bool")
+
+    monkeypatch.setattr(torch.Tensor, "__bool__", _forbid_tensor_bool)
+
+    grad_K = _grad_K_packed_direct(
+        means=means,
+        viewmats=viewmats,
+        camera_ids=camera_ids,
+        gaussian_ids=gaussian_ids,
+        v_means2d=v_means2d,
+        width=width,
+        height=height,
+    )
+
+    assert grad_K.shape == (C, 3, 3)
+
+
 def test_grad_K_visible_single_camera_matches_reference_for_masked_gradients():
     from gsplat.cuda._wrapper import _grad_K_reference, _grad_K_visible_single_camera
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -399,6 +399,7 @@ def test_fully_fused_projection_packed(
     means = test_data["means"]
 
     viewmats.requires_grad = True
+    Ks.requires_grad = True
     quats.requires_grad = True
     scales.requires_grad = True
     means.requires_grad = True
@@ -509,18 +510,18 @@ def test_fully_fused_projection_packed(
     v_means2d = torch.randn_like(_means2d) * sel[..., None]
     v_depths = torch.randn_like(_depths) * sel
     v_conics = torch.randn_like(_conics) * sel[..., None]
-    _v_viewmats, _v_quats, _v_scales, _v_means = torch.autograd.grad(
+    _v_viewmats, _v_Ks, _v_quats, _v_scales, _v_means = torch.autograd.grad(
         (_means2d * v_means2d).sum()
         + (_depths * v_depths).sum()
         + (_conics * v_conics).sum(),
-        (viewmats, quats, scales, means),
+        (viewmats, Ks, quats, scales, means),
         retain_graph=True,
     )
-    v_viewmats, v_quats, v_scales, v_means = torch.autograd.grad(
+    v_viewmats, v_Ks, v_quats, v_scales, v_means = torch.autograd.grad(
         (means2d * v_means2d[__radii > 0]).sum()
         + (depths * v_depths[__radii > 0]).sum()
         + (conics * v_conics[__radii > 0]).sum(),
-        (viewmats, quats, scales, means),
+        (viewmats, Ks, quats, scales, means),
         retain_graph=True,
     )
     if sparse_grad:
@@ -529,6 +530,7 @@ def test_fully_fused_projection_packed(
         v_means = v_means.to_dense()
 
     torch.testing.assert_close(v_viewmats, _v_viewmats, rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(v_Ks, _v_Ks, rtol=1e-4, atol=1e-4)
     torch.testing.assert_close(v_quats, _v_quats, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(v_scales, _v_scales, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(v_means, _v_means, rtol=1e-3, atol=1e-3)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,23 @@
+import inspect
+
+import pytest
+
+
+PUBLIC_FUNCS = [
+    ("gsplat.rendering", "rasterization"),
+    ("gsplat.rendering", "rasterization_2dgs"),
+    ("gsplat.cuda._wrapper", "fully_fused_projection"),
+    ("gsplat.cuda._wrapper", "fully_fused_projection_2dgs"),
+]
+
+
+@pytest.mark.parametrize(("module_name", "func_name"), PUBLIC_FUNCS)
+def test_public_rasterizers_default_packed_false(module_name: str, func_name: str):
+    module = __import__(module_name, fromlist=[func_name])
+    func = getattr(module, func_name)
+    sig = inspect.signature(func)
+    param = sig.parameters["packed"]
+    assert param.default is False, (
+        f"{module_name}.{func_name}.packed default is {param.default!r}; "
+        "expected False so the dense strategy is the default."
+    )


### PR DESCRIPTION
## Summary
- Add packed-mode `Ks` gradients for 3DGS projection matching existing unpacked behavior.
- Add packed-mode `Ks` and `viewmats` gradients for 2DGS projection, fix packed 2DGS per-camera intrinsics, and enable high-level `rasterization_2dgs(packed=True)`.
- Document known partial camera-gradient limitations for 3DGS and 2DGS.

## Latent bug fix
- `_FullyFusedProjectionPacked2DGS.backward` on the base branch returned 13 values for a forward that takes only 11 inputs after `ctx` (5 differentiable parameters + 6 non-differentiable). PyTorch currently tolerates the extras silently, but the autograd contract requires one gradient per forward input, so this is a latent correctness bug. The PR trims the return tuple to 11 entries (5 tensor entries + 6 trailing `None`), guarded by `test_fully_fused_projection_packed_2dgs_backward_return_arity`.

## Test Plan
- `python -m compileall gsplat/cuda/_wrapper.py gsplat/rendering.py tests/test_2dgs.py tests/test_basic.py`
- `git diff --check`
- `pytest -W ignore::pytest.PytestRemovedIn9Warning tests/test_2dgs.py::test_fully_fused_projection_packed_2dgs_backward_return_arity tests/test_2dgs.py::test_fully_fused_projection_packed_2dgs tests/test_2dgs.py::test_rasterization_2dgs_packed_matches_unpacked tests/test_basic.py::test_fully_fused_projection_packed -q`

## Notes
- This intentionally matches the current unpacked partial camera-gradient behavior. It does not implement full intrinsic derivatives through all covariance/conic/compensation or CUDA-folded 2DGS VJP paths.