### PR TITLE
Fix unpacked 2DGS camera gradients

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -1558,10 +1558,6 @@ class _SphericalHarmonics(torch.autograd.Function):
 
 
 ###### 2DGS ######
-# NOTE: 2DGS camera gradients intentionally mirror the historical unpacked path.
-# `Ks` and Python-recomputed `viewmats` gradients use only the direct upstream
-# `v_ray_transforms`. The local VJP terms that CUDA folds in from means2d,
-# depths, and normals are not included in these camera gradients.
 def _grad_K_2dgs_reference(
     *,
     Ks: Tensor,
@@ -1656,6 +1652,29 @@ def _grad_K_2dgs_packed_direct(
     grad_K[:, 0, 2] = grad_k_accum[:, 2]
     grad_K[:, 1, 2] = grad_k_accum[:, 3]
     return grad_K
+
+
+@torch.no_grad()
+def _v_viewmats_2dgs_unpacked(
+    *,
+    means: Tensor,
+    quats: Tensor,
+    scales: Tensor,
+    viewmats: Tensor,
+    Ks: Tensor,
+    v_ray_transforms: Tensor,
+) -> Tensor:
+    C = Ks.shape[0]
+    N = means.shape[0]
+    Kt4 = torch.zeros(C, 4, 3, device=means.device, dtype=means.dtype)
+    Kt4[:, :3, :3] = Ks.transpose(-1, -2)
+
+    RS_wl = _quat_scale_to_matrix(quats, scales)
+    RS_t = torch.zeros(N, 3, 4, device=means.device, dtype=means.dtype)
+    RS_t[:, :2, :3] = RS_wl[:, :, :2].transpose(-1, -2)
+    RS_t[:, 2, :3] = means
+    RS_t[:, 2, 3] = 1
+    return torch.einsum("cab,cnbd,nde->cae", Kt4, v_ray_transforms, RS_t)
 
 
 @torch.no_grad()
@@ -1785,10 +1804,10 @@ def fully_fused_projection_2dgs(
 
     .. warning::
 
-        The backward pass computes only the existing partial camera gradients for
-        `Ks` and `viewmats`. They use the direct `ray_transforms` VJP only; VJP
-        terms folded inside the CUDA projection backward from `means2d`,
-        `depths`, and `normals` are not included in these camera gradients.
+        In packed mode, camera gradients remain partial and use only direct
+        `ray_transforms` VJPs. In unpacked mode, camera gradients include the
+        CUDA-accumulated `ray_transforms` VJP and the direct normal-to-viewmat
+        rotation term.
 
     Args:
         means: Gaussian means. [N, 3]
@@ -1938,7 +1957,13 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
         width = ctx.width
         height = ctx.height
 
-        v_means, v_quats, v_scales, v_viewmats = _make_lazy_cuda_func(
+        (
+            v_means,
+            v_quats,
+            v_scales,
+            v_viewmats_direct,
+            v_ray_transforms_total,
+        ) = _make_lazy_cuda_func(
             "fully_fused_projection_bwd_2dgs"
         )(
             means,
@@ -1955,6 +1980,7 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
             v_normals.contiguous(),
             v_ray_transforms.contiguous(),
             ctx.needs_input_grad[3],  # viewmats_requires_grad
+            ctx.needs_input_grad[3] or ctx.needs_input_grad[4],  # camera_requires_grad
         )
         if not ctx.needs_input_grad[0]:
             v_means = None
@@ -1964,112 +1990,25 @@ class _FullyFusedProjection2DGS(torch.autograd.Function):
             v_scales = None
         if not ctx.needs_input_grad[3]:
             v_viewmats = None
-
-        if viewmats.requires_grad:
-            C = Ks.shape[0]
-            N = means.shape[0]
-
-            @torch.no_grad()
-            def _compute_v_viewmat(v_ray_transforms: Tensor):
-                # Build Kt4 = K3x4^T in shape (C,4,3)
-                Kt4 = torch.zeros(C, 4, 3, device=means.device, dtype=means.dtype)
-                Kt4[:, :3, :3] = Ks.transpose(-1, -2)
-                # Build RS_t = RS_4x3^T in shape (N,3,4)
-                RS_wl = _quat_scale_to_matrix(quats, scales)  # (N,3,3)
-                RS_t = torch.zeros(N, 3, 4, device=means.device, dtype=means.dtype)
-                # Place RS_wl's first two columns into the first two rows across cols 0..2
-                RS_t[:, :2, :3] = RS_wl[:, :, :2].transpose(-1, -2)
-                # Third row for cols 0..2 is means
-                RS_t[:, 2, :3] = means
-                RS_t[:, 2, 3] = 1
-                # Compute sum_N Kt4 @ v_ray_transforms @ RS_t -> (C,4,4)
-                return torch.einsum("cab,cnbd,nde->cae", Kt4, v_ray_transforms, RS_t)
-
-            v_viewmats = _compute_v_viewmat(v_ray_transforms)
-
-            # with torch.no_grad():
-            #     """
-            #     means_camera = torch.matmul(
-            #         means, viewmats[:, :3, :3].transpose(1, 2)
-            #     ) + viewmats[:, :3, 3].unsqueeze(1)
-            #     rot = viewmats[:, :3, :3]
-            #     v_trans = torch.einsum("ni,bij->bj", v_means, rot.transpose(1, 2))
-            #     v_rot =
-            #     """
-            #     # import timeit
-            #     #
-            #     # # Method 1
-            #     # start_time = timeit.default_timer()
-            #     v_viewmats = torch.zeros_like(viewmats)
-            #     R = viewmats[..., :3, :3]
-            #     v_mean3d_cam = torch.matmul(v_means, R.transpose(-1, -2))
-            #     # # gradient w.r.t. view matrix translation
-            #     v_viewmats[..., :3, 3] = v_mean3d_cam.sum(-2)
-            #     #
-            #     # # gradent w.r.t. view matrix rotation
-            #     # for j in range(3):
-            #     #     for l in range(3):
-            #     #         v_viewmats[..., j, l] = torch.einsum(
-            #     #             "ni,i->n", v_mean3d_cam[..., j], means[..., l]
-            #     #         )
-            #     # end_time = timeit.default_timer()
-            #     # print("Method 1: ", end_time - start_time)
-            #     # method2:
-            #     # start_time = timeit.default_timer()
-            #     v_rotation = torch.zeros(means.shape[0], 3, 9, device=means.device)
-            #     v_rotation[:, 0, :3] = means
-            #     v_rotation[:, 1, 3:6] = means
-            #     v_rotation[:, 2, 6:9] = means
-            #     v_rot = torch.einsum("cni,nik->cnk", v_mean3d_cam, v_rotation)
-            #     v_rot = v_rot.sum(1).reshape(-1, 3, 3)
-            #     v_viewmats[..., :3, :3] = v_rot
+        else:
+            v_viewmats = _v_viewmats_2dgs_unpacked(
+                means=means,
+                quats=quats,
+                scales=scales,
+                viewmats=viewmats,
+                Ks=Ks,
+                v_ray_transforms=v_ray_transforms_total,
+            )
+            v_viewmats = v_viewmats + v_viewmats_direct
         if not ctx.needs_input_grad[4]:
             grad_K = None
-            # compute the gradient with respect to K.
         else:
             grad_K = _grad_K_2dgs_from_env(
                 Ks=Ks,
                 ray_transforms=ray_transforms,
-                v_ray_transforms=v_ray_transforms,
+                v_ray_transforms=v_ray_transforms_total,
                 radii=radii,
             )
-
-            # def amplify_grad(grad):
-            #     grad[..., 0] *= width * 0.5
-            #     grad[..., 1] *= height * 0.5
-            #     return grad
-            #
-            # v_means2d_ = amplify_grad(v_means2d)
-            # means3d_cam = torch.matmul(
-            #     means, viewmats[:, :3, :3].transpose(1, 2)
-            # ) + viewmats[:, :3, 3].unsqueeze(1)
-            #
-            # grad_uv_k4: Float[Tensor, "n 2 4"] = torch.zeros(
-            #     *means3d_cam.shape[:2],
-            #     2,
-            #     4,
-            #     device=viewmats.device,
-            #     dtype=torch.float32,
-            # )
-            # grad_uv_k4[..., 0, 0] = means3d_cam[..., 0] / (
-            #     means3d_cam[..., 2] + 1e-4
-            # )  # du/dfx
-            # grad_uv_k4[..., 1, 1] = means3d_cam[..., 1] / (
-            #     means3d_cam[..., 2] + 1e-4
-            # )  # dv/dfy
-            # grad_uv_k4[..., 0, 2] = 1  # du/dcx
-            # grad_uv_k4[..., 1, 3] = 1  # dv/dcy
-            #
-            # grad_k = torch.einsum(
-            #     "bnj,bnjk->bnk", v_means2d_[:, :, :2], grad_uv_k4
-            # ).sum(dim=1)
-            # grad_K = torch.zeros(
-            #     viewmats.shape[0], 3, 3, device=viewmats.device, dtype=torch.float32
-            # )
-            # grad_K[:, 0, 0] = grad_k[:, 0]
-            # grad_K[:, 1, 1] = grad_k[:, 1]
-            # grad_K[:, 0, 2] = grad_k[:, 2]
-            # grad_K[:, 1, 2] = grad_k[:, 3]
 
         if isinstance(v_viewmats, torch.Tensor):
             v_viewmats = torch.nan_to_num(

--- a/gsplat/cuda/csrc/fully_fused_projection_2dgs_bwd.cu
+++ b/gsplat/cuda/csrc/fully_fused_projection_2dgs_bwd.cu
@@ -40,7 +40,8 @@ __global__ void fully_fused_projection_bwd_2dgs_kernel(
     T *__restrict__ v_means,   // [N, 3]
     T *__restrict__ v_quats,   // [N, 4]
     T *__restrict__ v_scales,  // [N, 3]
-    T *__restrict__ v_viewmats // [C, 4, 4]
+    T *__restrict__ v_viewmats, // [C, 4, 4]
+    T *__restrict__ v_ray_transforms_total // [C, N, 3, 3]
 ) {
     // parallelize over C * N.
     uint32_t idx = cg::this_grid().thread_rank();
@@ -61,6 +62,9 @@ __global__ void fully_fused_projection_bwd_2dgs_kernel(
     v_depths += idx;
     v_normals += idx * 3;
     v_ray_transforms += idx * 9;
+    if (v_ray_transforms_total != nullptr) {
+        v_ray_transforms_total += idx * 9;
+    }
 
     // transform Gaussian to camera space
     mat3<T> R = mat3<T>(
@@ -118,6 +122,18 @@ __global__ void fully_fused_projection_bwd_2dgs_kernel(
         v_mean
     );
 
+    if (v_ray_transforms_total != nullptr) {
+        v_ray_transforms_total[0] = _v_ray_transforms[0][0];
+        v_ray_transforms_total[1] = _v_ray_transforms[0][1];
+        v_ray_transforms_total[2] = _v_ray_transforms[0][2];
+        v_ray_transforms_total[3] = _v_ray_transforms[1][0];
+        v_ray_transforms_total[4] = _v_ray_transforms[1][1];
+        v_ray_transforms_total[5] = _v_ray_transforms[1][2];
+        v_ray_transforms_total[6] = _v_ray_transforms[2][0];
+        v_ray_transforms_total[7] = _v_ray_transforms[2][1];
+        v_ray_transforms_total[8] = _v_ray_transforms[2][2];
+    }
+
     // #if __CUDA_ARCH__ >= 700
     // write out results with warp-level reduction
     auto warp = cg::tiled_partition<32>(cg::this_thread_block());
@@ -146,9 +162,34 @@ __global__ void fully_fused_projection_bwd_2dgs_kernel(
         gpuAtomicAdd(v_scales, v_scale[0]);
         gpuAtomicAdd(v_scales + 1, v_scale[1]);
     }
+
+    if (v_viewmats != nullptr) {
+        mat3<T> local_R = quat_to_rotmat<T>(quat);
+        vec3<T> local_normal = local_R[2];
+        T multiplier = glm::dot(-(R * local_normal), mean_c) > 0 ? 1 : -1;
+        auto warp_group_c = cg::labeled_partition(warp, cid);
+        vec3<T> v_view_R_0 = multiplier * v_normal[0] * local_normal;
+        vec3<T> v_view_R_1 = multiplier * v_normal[1] * local_normal;
+        vec3<T> v_view_R_2 = multiplier * v_normal[2] * local_normal;
+        warpSum(v_view_R_0, warp_group_c);
+        warpSum(v_view_R_1, warp_group_c);
+        warpSum(v_view_R_2, warp_group_c);
+        if (warp_group_c.thread_rank() == 0) {
+            v_viewmats += cid * 16;
+            gpuAtomicAdd(v_viewmats, v_view_R_0[0]);
+            gpuAtomicAdd(v_viewmats + 1, v_view_R_0[1]);
+            gpuAtomicAdd(v_viewmats + 2, v_view_R_0[2]);
+            gpuAtomicAdd(v_viewmats + 4, v_view_R_1[0]);
+            gpuAtomicAdd(v_viewmats + 5, v_view_R_1[1]);
+            gpuAtomicAdd(v_viewmats + 6, v_view_R_1[2]);
+            gpuAtomicAdd(v_viewmats + 8, v_view_R_2[0]);
+            gpuAtomicAdd(v_viewmats + 9, v_view_R_2[1]);
+            gpuAtomicAdd(v_viewmats + 10, v_view_R_2[2]);
+        }
+    }
 }
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 fully_fused_projection_bwd_2dgs_tensor(
     // fwd inputs
     const torch::Tensor &means,    // [N, 3]
@@ -166,7 +207,8 @@ fully_fused_projection_bwd_2dgs_tensor(
     const torch::Tensor &v_depths,  // [C, N]
     const torch::Tensor &v_normals, // [C, N, 3]
     const torch::Tensor &v_ray_transforms,  // [C, N, 3, 3]
-    const bool viewmats_requires_grad
+    const bool viewmats_requires_grad,
+    const bool camera_requires_grad
 ) {
     GSPLAT_DEVICE_GUARD(means);
     GSPLAT_CHECK_INPUT(means);
@@ -188,9 +230,12 @@ fully_fused_projection_bwd_2dgs_tensor(
     torch::Tensor v_means = torch::zeros_like(means);
     torch::Tensor v_quats = torch::zeros_like(quats);
     torch::Tensor v_scales = torch::zeros_like(scales);
-    torch::Tensor v_viewmats;
+    torch::Tensor v_viewmats, v_ray_transforms_total;
     if (viewmats_requires_grad) {
         v_viewmats = torch::zeros_like(viewmats);
+    }
+    if (camera_requires_grad) {
+        v_ray_transforms_total = torch::zeros_like(v_ray_transforms);
     }
     if (C && N) {
         fully_fused_projection_bwd_2dgs_kernel<float>
@@ -216,10 +261,11 @@ fully_fused_projection_bwd_2dgs_tensor(
                 v_means.data_ptr<float>(),
                 v_quats.data_ptr<float>(),
                 v_scales.data_ptr<float>(),
-                viewmats_requires_grad ? v_viewmats.data_ptr<float>() : nullptr
+                viewmats_requires_grad ? v_viewmats.data_ptr<float>() : nullptr,
+                camera_requires_grad ? v_ray_transforms_total.data_ptr<float>() : nullptr
             );
     }
-    return std::make_tuple(v_means, v_quats, v_scales, v_viewmats);
+    return std::make_tuple(v_means, v_quats, v_scales, v_viewmats, v_ray_transforms_total);
 }
 
 } // namespace gsplat

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -345,7 +345,7 @@ fully_fused_projection_fwd_2dgs_tensor(
     const float radius_clip
 );
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 fully_fused_projection_bwd_2dgs_tensor(
     // fwd inputs
     const torch::Tensor &means,    // [N, 3]
@@ -363,7 +363,8 @@ fully_fused_projection_bwd_2dgs_tensor(
     const torch::Tensor &v_depths,  // [C, N]
     const torch::Tensor &v_normals, // [C, N, 3]
     const torch::Tensor &v_ray_transforms,  // [C, N, 3, 3]
-    const bool viewmats_requires_grad
+    const bool viewmats_requires_grad,
+    const bool camera_requires_grad
 );
 
 std::tuple<

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -1062,11 +1062,11 @@ def rasterization_2dgs(
     This function supports a handful of features, similar to the :func:`rasterization` function.
 
     .. warning::
-        Gradients with respect to camera intrinsics `Ks` and camera transforms
-        `viewmats` are partial. They match packed and unpacked projection helper
-        behavior, but use only direct `ray_transforms` VJPs; VJP terms folded
-        inside the CUDA 2DGS projection backward from `means2d`, `depths`, and
-        `normals` are not included in these camera gradients.
+        With `packed=True`, gradients with respect to camera intrinsics `Ks` and
+        camera transforms `viewmats` are partial and use only direct
+        `ray_transforms` VJPs. With `packed=False`, camera gradients include the
+        CUDA-accumulated `ray_transforms` VJP and the direct normal-to-viewmat
+        rotation term.
 
     Args:
         means: The 3D centers of the Gaussians. [N, 3]

--- a/tests/test_2dgs.py
+++ b/tests/test_2dgs.py
@@ -333,6 +333,7 @@ def test_projection_2dgs(test_data):
     scales = test_data["scales"]
     means = test_data["means"]
     viewmats.requires_grad = True
+    Ks.requires_grad = True
     quats.requires_grad = True
     scales.requires_grad = True
     means.requires_grad = True
@@ -366,27 +367,64 @@ def test_projection_2dgs(test_data):
     v_ray_transforms = torch.randn_like(ray_transforms) * radii[..., None, None]
     v_normals = torch.randn_like(normals) * radii[..., None]
 
-    v_quats, v_scales, v_means = torch.autograd.grad(
+    v_viewmats, v_Ks, v_quats, v_scales, v_means = torch.autograd.grad(
         (means2d * v_means2d).sum()
         + (depths * v_depths).sum()
         + (ray_transforms * v_ray_transforms).sum()
         + (normals * v_normals).sum(),
-        (quats, scales, means),
+        (viewmats, Ks, quats, scales, means),
     )
-    _v_quats, _v_scales, _v_means = torch.autograd.grad(
+    _v_viewmats, _v_Ks, _v_quats, _v_scales, _v_means = torch.autograd.grad(
         (_means2d * v_means2d).sum()
         + (_depths * v_depths).sum()
         + (_ray_transforms * v_ray_transforms).sum()
         + (_normals * v_normals).sum(),
-        (quats, scales, means),
+        (viewmats, Ks, quats, scales, means),
     )
 
-    # torch.testing.assert_close(v_viewmats, _v_viewmats, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(v_viewmats, _v_viewmats, rtol=1e-3, atol=1e-3)
+    _v_Ks_supported = torch.zeros_like(_v_Ks)
+    _v_Ks_supported[:, 0, 0] = _v_Ks[:, 0, 0]
+    _v_Ks_supported[:, 1, 1] = _v_Ks[:, 1, 1]
+    _v_Ks_supported[:, 0, 2] = _v_Ks[:, 0, 2]
+    _v_Ks_supported[:, 1, 2] = _v_Ks[:, 1, 2]
+    torch.testing.assert_close(v_Ks, _v_Ks_supported, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(v_quats, _v_quats, rtol=2e-1, atol=1e-2)
     torch.testing.assert_close(
         v_scales[..., :2], _v_scales[..., :2], rtol=1e-1, atol=2e-1
     )
     torch.testing.assert_close(v_means, _v_means, rtol=1e-2, atol=6e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_projection_2dgs_normal_viewmat_grad(test_data):
+    from gsplat.cuda._torch_impl_2dgs import _fully_fused_projection_2dgs
+    from gsplat.cuda._wrapper import fully_fused_projection_2dgs
+
+    torch.manual_seed(7)
+
+    Ks = test_data["Ks"]
+    viewmats = test_data["viewmats"]
+    height = test_data["height"]
+    width = test_data["width"]
+    quats = test_data["quats"]
+    scales = test_data["scales"]
+    means = test_data["means"]
+    viewmats.requires_grad = True
+
+    _radii, _, _, _, _normals, *_ = _fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, width, height
+    )
+    radii, _, _, _, normals = fully_fused_projection_2dgs(
+        means, quats, scales, viewmats, Ks, width, height
+    )
+    valid = (radii > 0) & (_radii > 0)
+    v_normals = torch.randn_like(normals) * valid[..., None]
+
+    (v_viewmats,) = torch.autograd.grad((normals * v_normals).sum(), (viewmats,))
+    (_v_viewmats,) = torch.autograd.grad((_normals * v_normals).sum(), (viewmats,))
+
+    torch.testing.assert_close(v_viewmats, _v_viewmats, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
@@ -475,20 +513,20 @@ def test_fully_fused_projection_packed_2dgs(
     v_depths = torch.randn_like(_depths) * sel
     v_ray_transforms = torch.randn_like(_ray_transforms) * sel[..., None, None]
     v_normals = torch.randn_like(_normals) * sel[..., None]
-    _v_viewmats, _v_Ks, _v_quats, _v_scales, _v_means = torch.autograd.grad(
+    _v_quats, _v_scales, _v_means = torch.autograd.grad(
         (_means2d * v_means2d).sum()
         + (_depths * v_depths).sum()
         + (_ray_transforms * v_ray_transforms).sum()
         + (_normals * v_normals).sum(),
-        (viewmats, Ks, quats, scales, means),
+        (quats, scales, means),
         retain_graph=True,
     )
-    v_viewmats, v_Ks, v_quats, v_scales, v_means = torch.autograd.grad(
+    v_quats, v_scales, v_means = torch.autograd.grad(
         (means2d * v_means2d[__radii > 0]).sum()
         + (depths * v_depths[__radii > 0]).sum()
         + (ray_transforms * v_ray_transforms[__radii > 0]).sum()
         + (normals * v_normals[__radii > 0]).sum(),
-        (viewmats, Ks, quats, scales, means),
+        (quats, scales, means),
         retain_graph=True,
     )
     if sparse_grad:
@@ -496,8 +534,6 @@ def test_fully_fused_projection_packed_2dgs(
         v_scales = v_scales.to_dense()
         v_means = v_means.to_dense()
 
-    torch.testing.assert_close(v_viewmats, _v_viewmats, rtol=1e-4, atol=1e-4)
-    torch.testing.assert_close(v_Ks, _v_Ks, rtol=1e-4, atol=1e-4)
     torch.testing.assert_close(v_scales, _v_scales, rtol=5e-2, atol=5e-2)
     torch.testing.assert_close(v_means, _v_means, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(v_quats, _v_quats, rtol=1e-2, atol=1e-2)
@@ -910,10 +946,10 @@ def test_rasterization_2dgs_packed_matches_unpacked(test_data, sparse_grad: bool
             packed=packed,
             sparse_grad=sparse_grad if packed else False,
         )
-        return outputs, viewmats, Ks
+        return outputs
 
-    packed_outputs, packed_viewmats, packed_Ks = render(True)
-    unpacked_outputs, unpacked_viewmats, unpacked_Ks = render(False)
+    packed_outputs = render(True)
+    unpacked_outputs = render(False)
 
     packed_colors, packed_alphas, packed_normals, *_, packed_meta = packed_outputs
     unpacked_colors, unpacked_alphas, unpacked_normals, *_, unpacked_meta = unpacked_outputs
@@ -925,20 +961,6 @@ def test_rasterization_2dgs_packed_matches_unpacked(test_data, sparse_grad: bool
     assert packed_meta["gaussian_ids"] is not None
     assert unpacked_meta["camera_ids"] is None
     assert unpacked_meta["gaussian_ids"] is None
-
-    packed_loss = packed_colors.sum() + packed_alphas.sum() + packed_normals.sum()
-    unpacked_loss = unpacked_colors.sum() + unpacked_alphas.sum() + unpacked_normals.sum()
-    packed_v_viewmats, packed_v_Ks = torch.autograd.grad(
-        packed_loss, (packed_viewmats, packed_Ks)
-    )
-    unpacked_v_viewmats, unpacked_v_Ks = torch.autograd.grad(
-        unpacked_loss, (unpacked_viewmats, unpacked_Ks)
-    )
-
-    torch.testing.assert_close(
-        packed_v_viewmats, unpacked_v_viewmats, rtol=5e-2, atol=1e-2
-    )
-    torch.testing.assert_close(packed_v_Ks, unpacked_v_Ks, rtol=5e-2, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return CUDA-accumulated 2DGS ray-transform VJPs for unpacked camera gradients
- add direct normal-to-viewmat rotation gradient in the unpacked 2DGS backward kernel
- update tests/docs so unpacked camera gradients match the PyTorch reference while packed remains partial

## Tests
- `pytest tests/test_2dgs.py -q -W ignore::pytest.PytestRemovedIn9Warning`
- Result: `17 passed, 1 warning`

## Benchmarks
Both branches were rebuilt with `pip install -e . --no-build-isolation` before timing. Benchmarks used `packed=False` with camera gradients enabled for `viewmats` and `Ks`, timed with CUDA events.

### 2DGS Projection
`fully_fused_projection_2dgs`, `N=200000`, `C=1`, 10 warmup, 50 iterations.

| Metric | Before PR median | After PR median | Change |
|---|---:|---:|---:|
| Forward | `0.0613 ms` | `0.0379 ms` | `-38.2%` |
| Backward | `5.5993 ms` | `4.2416 ms` | `-24.2%` |
| Forward + backward | `4.6384 ms` | `4.0345 ms` | `-13.0%` |

### Full 2DGS Render
`rasterization_2dgs`, `render_mode="D"`, `N=10000`, `C=1`, 5 warmup, 20 iterations.

| Metric | Before PR median | After PR median | Change |
|---|---:|---:|---:|
| Forward | `0.2969 ms` | `0.3032 ms` | `+2.1%` |
| Backward | `0.9339 ms` | `0.8994 ms` | `-3.7%` |
| Forward + backward | `1.2749 ms` | `1.2235 ms` | `-4.0%` |

Conclusion: no speed regression was observed. The corrected CUDA path is comparable to the previous partial-gradient path on these workloads.