### PR TITLE
Add per-channel ray-color consistency gradients

### DIFF
--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -2277,6 +2277,7 @@ def rasterize_to_pixels_2dgs(
     packed: bool = False,
     absgrad: bool = False,
     distloss: bool = False,
+    ray_color_weights: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor]:
     """Rasterize Gaussians to pixels.
 
@@ -2294,6 +2295,10 @@ def rasterize_to_pixels_2dgs(
         masks: Optional tile mask to skip rendering GS to masked tiles. [C, tile_height, tile_width]. Default: None.
         packed: If True, the input tensors are expected to be packed with shape [nnz, ...]. Default: False.
         absgrad: If True, the backward pass will compute a `.absgrad` attribute for `means2d`. Default: False.
+        ray_color_weights: Optional per-channel weights for backward-only ray-color
+            consistency. The target is the detached raw composited rasterizer value,
+            including the background. Dynamic loss scaling must also be applied to
+            these weights. Default: None.
 
     Returns:
         A tuple:
@@ -2326,6 +2331,19 @@ def rasterize_to_pixels_2dgs(
 
     # Pad the channels to the nearest supported number if necessary
     channels = colors.shape[-1]
+    if ray_color_weights is not None:
+        if ray_color_weights.shape != (channels,):
+            raise ValueError(
+                "ray_color_weights must have shape "
+                f"({channels},), got {tuple(ray_color_weights.shape)}"
+            )
+        if ray_color_weights.device != device:
+            raise ValueError("ray_color_weights must be on the same device as colors")
+        if ray_color_weights.dtype != colors.dtype:
+            raise ValueError("ray_color_weights must have the same dtype as colors")
+        if ray_color_weights.requires_grad:
+            raise ValueError("ray_color_weights must not require gradients")
+        ray_color_weights = ray_color_weights.contiguous()
     if channels > 512 or channels == 0:
         # TODO: maybe worth to support zero channels?
         raise ValueError(f"Unsupported number of color channels: {channels}")
@@ -2344,6 +2362,17 @@ def rasterize_to_pixels_2dgs(
                     ),
                 ],
                 dim=-1,
+            )
+        if ray_color_weights is not None:
+            ray_color_weights = torch.cat(
+                [
+                    ray_color_weights,
+                    torch.zeros(
+                        padded_channels,
+                        device=device,
+                        dtype=ray_color_weights.dtype,
+                    ),
+                ]
             )
     else:
         padded_channels = 0
@@ -2377,6 +2406,7 @@ def rasterize_to_pixels_2dgs(
         flatten_ids.contiguous(),
         absgrad,
         distloss,
+        ray_color_weights,
     )
 
     if padded_channels > 0:
@@ -2483,6 +2513,7 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
         flatten_ids: Tensor,
         absgrad: bool,
         distloss: bool,
+        ray_color_weights: Tensor,
     ) -> Tuple[Tensor, Tensor]:
         (
             render_colors,
@@ -2522,6 +2553,7 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             render_alphas,
             last_ids,
             median_ids,
+            ray_color_weights,
         )
         ctx.width = width
         ctx.height = height
@@ -2563,6 +2595,7 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             render_alphas,
             last_ids,
             median_ids,
+            ray_color_weights,
         ) = ctx.saved_tensors
         width = ctx.width
         height = ctx.height
@@ -2601,6 +2634,7 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             v_render_distort.contiguous(),
             v_render_median.contiguous(),
             absgrad,
+            ray_color_weights,
         )
         if absgrad:
             means2d.absgrad = v_means2d_abs
@@ -2620,6 +2654,7 @@ class _RasterizeToPixels2DGS(torch.autograd.Function):
             v_normals,
             v_densify,
             v_backgrounds,
+            None,
             None,
             None,
             None,

--- a/gsplat/cuda/_wrapper.py
+++ b/gsplat/cuda/_wrapper.py
@@ -532,6 +532,7 @@ def rasterize_to_pixels(
     masks: Optional[Tensor] = None,  # [C, tile_height, tile_width]
     packed: bool = False,
     absgrad: bool = False,
+    ray_color_weights: Optional[Tensor] = None,  # [channels]
 ) -> Tuple[Tensor, Tensor]:
     """Rasterizes Gaussians to pixels.
 
@@ -549,6 +550,13 @@ def rasterize_to_pixels(
         masks: Optional tile mask to skip rendering GS to masked tiles. [C, tile_height, tile_width]. Default: None.
         packed: If True, the input tensors are expected to be packed with shape [nnz, ...]. Default: False.
         absgrad: If True, the backward pass will compute a `.absgrad` attribute for `means2d`. Default: False.
+        ray_color_weights: Optional per-channel weights for backward-only ray-color
+            consistency. The additional color gradient is
+            `weight * alpha * transmittance * (gaussian_color - rendered_color)`.
+            The rendered target includes the background and is detached, as are the
+            blending weights. This gradient is independent of the rendered image's
+            upstream gradient, so dynamic loss scaling must also be applied to these
+            weights. Default: None.
 
     Returns:
         A tuple:
@@ -580,6 +588,19 @@ def rasterize_to_pixels(
 
     # Pad the channels to the nearest supported number if necessary
     channels = colors.shape[-1]
+    if ray_color_weights is not None:
+        if ray_color_weights.shape != (channels,):
+            raise ValueError(
+                "ray_color_weights must have shape "
+                f"({channels},), got {tuple(ray_color_weights.shape)}"
+            )
+        if ray_color_weights.device != device:
+            raise ValueError("ray_color_weights must be on the same device as colors")
+        if ray_color_weights.dtype != colors.dtype:
+            raise ValueError("ray_color_weights must have the same dtype as colors")
+        if ray_color_weights.requires_grad:
+            raise ValueError("ray_color_weights must not require gradients")
+        ray_color_weights = ray_color_weights.contiguous()
     if channels > 513 or channels == 0:
         # TODO: maybe worth to support zero channels?
         raise ValueError(f"Unsupported number of color channels: {channels}")
@@ -622,6 +643,17 @@ def rasterize_to_pixels(
                 ],
                 dim=-1,
             )
+        if ray_color_weights is not None:
+            ray_color_weights = torch.cat(
+                [
+                    ray_color_weights,
+                    torch.zeros(
+                        padded_channels,
+                        device=device,
+                        dtype=ray_color_weights.dtype,
+                    ),
+                ]
+            )
     else:
         padded_channels = 0
 
@@ -646,6 +678,7 @@ def rasterize_to_pixels(
         isect_offsets.contiguous(),
         flatten_ids.contiguous(),
         absgrad,
+        ray_color_weights,
     )
 
     if padded_channels > 0:
@@ -1205,6 +1238,7 @@ class _RasterizeToPixels(torch.autograd.Function):
         isect_offsets: Tensor,  # [C, tile_height, tile_width]
         flatten_ids: Tensor,  # [n_isects]
         absgrad: bool,
+        ray_color_weights: Tensor,  # [D], Optional
     ) -> Tuple[Tensor, Tensor]:
         render_colors, render_alphas, last_ids = _make_lazy_cuda_func(
             "rasterize_to_pixels_fwd"
@@ -1233,6 +1267,8 @@ class _RasterizeToPixels(torch.autograd.Function):
             flatten_ids,
             render_alphas,
             last_ids,
+            render_colors if ray_color_weights is not None else None,
+            ray_color_weights,
         )
         ctx.width = width
         ctx.height = height
@@ -1260,6 +1296,8 @@ class _RasterizeToPixels(torch.autograd.Function):
             flatten_ids,
             render_alphas,
             last_ids,
+            render_colors,
+            ray_color_weights,
         ) = ctx.saved_tensors
         width = ctx.width
         height = ctx.height
@@ -1286,9 +1324,11 @@ class _RasterizeToPixels(torch.autograd.Function):
             flatten_ids,
             render_alphas,
             last_ids,
+            render_colors,
             v_render_colors.contiguous(),
             v_render_alphas.contiguous(),
             absgrad,
+            ray_color_weights,
         )
 
         if absgrad:
@@ -1307,6 +1347,7 @@ class _RasterizeToPixels(torch.autograd.Function):
             v_colors,
             v_opacities,
             v_backgrounds,
+            None,
             None,
             None,
             None,

--- a/gsplat/cuda/csrc/rasterize_to_pixels_2dgs_bwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_2dgs_bwd.cu
@@ -40,6 +40,7 @@ __global__ void rasterize_to_pixels_bwd_2dgs_kernel(
     // fwd outputs
     const S *__restrict__ render_colors,    // [C, image_height, image_width,
                                             // COLOR_DIM]
+    const S *__restrict__ ray_color_weights, // [COLOR_DIM]
     const S *__restrict__ render_alphas,    // [C, image_height, image_width, 1]
     const int32_t *__restrict__ last_ids,   // [C, image_height, image_width]     // the id to last gaussian that got intersected 
     const int32_t *__restrict__ median_ids, // [C, image_height, image_width]     // the id to the gaussian that brings the opacity over 0.5
@@ -74,6 +75,7 @@ __global__ void rasterize_to_pixels_bwd_2dgs_kernel(
     uint32_t j = block.group_index().z * tile_size + block.thread_index().x;
 
     tile_offsets += camera_id * tile_height * tile_width;
+    render_colors += camera_id * image_height * image_width * COLOR_DIM;
     render_alphas += camera_id * image_height * image_width;
     
     last_ids += camera_id * image_height * image_width;
@@ -405,7 +407,14 @@ __global__ void rasterize_to_pixels_bwd_2dgs_kernel(
                 const S fac = alpha * T;
                 GSPLAT_PRAGMA_UNROLL
                 for (uint32_t k = 0; k < COLOR_DIM; ++k) {
-                    v_rgb_local[k] += fac * v_render_c[k];
+                    S grad_factor = v_render_c[k];
+                    if (ray_color_weights != nullptr) {
+                        grad_factor +=
+                            ray_color_weights[k] *
+                            (rgbs_batch[t * COLOR_DIM + k] -
+                             render_colors[pix_id * COLOR_DIM + k]);
+                    }
+                    v_rgb_local[k] += fac * grad_factor;
                 }
 
                 // contribution from this pixel to alpha
@@ -646,7 +655,8 @@ call_kernel_with_dim(
     const torch::Tensor &v_render_distort, // [C, image_height, image_width, 1]
     const torch::Tensor &v_render_median,  // [C, image_height, image_width, 1]
     // options
-    bool absgrad
+    bool absgrad,
+    const at::optional<torch::Tensor> &ray_color_weights // [COLOR_DIM]
 ) {
 
     GSPLAT_DEVICE_GUARD(means2d);
@@ -667,6 +677,9 @@ call_kernel_with_dim(
     GSPLAT_CHECK_INPUT(v_render_normals);
     GSPLAT_CHECK_INPUT(v_render_distort);
     GSPLAT_CHECK_INPUT(v_render_median);
+    if (ray_color_weights.has_value()) {
+        GSPLAT_CHECK_INPUT(ray_color_weights.value());
+    }
     if (backgrounds.has_value()) {
         GSPLAT_CHECK_INPUT(backgrounds.value());
     }
@@ -740,6 +753,9 @@ call_kernel_with_dim(
                 tile_offsets.data_ptr<int32_t>(),
                 flatten_ids.data_ptr<int32_t>(),
                 render_colors.data_ptr<float>(),
+                ray_color_weights.has_value()
+                    ? ray_color_weights.value().data_ptr<float>()
+                    : nullptr,
                 render_alphas.data_ptr<float>(),
                 last_ids.data_ptr<int32_t>(),
                 median_ids.data_ptr<int32_t>(),
@@ -810,7 +826,8 @@ rasterize_to_pixels_bwd_2dgs_tensor(
     const torch::Tensor &v_render_distort, // [C, image_height, image_width, 1]
     const torch::Tensor &v_render_median,  // [C, image_height, image_width, 1]
     // options
-    bool absgrad
+    bool absgrad,
+    const at::optional<torch::Tensor> &ray_color_weights // [COLOR_DIM]
 ) {
 
     GSPLAT_CHECK_INPUT(colors);
@@ -841,7 +858,8 @@ rasterize_to_pixels_bwd_2dgs_tensor(
             v_render_normals,                                                  \
             v_render_distort,                                                  \
             v_render_median,                                                   \
-            absgrad                                                            \
+            absgrad,                                                           \
+            ray_color_weights                                                  \
         );
 
     switch (COLOR_DIM) {

--- a/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
+++ b/gsplat/cuda/csrc/rasterize_to_pixels_bwd.cu
@@ -36,6 +36,9 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     // fwd outputs
     const S *__restrict__ render_alphas,  // [C, image_height, image_width, 1]
     const int32_t *__restrict__ last_ids, // [C, image_height, image_width]
+    const S *__restrict__ render_colors, // [C, image_height, image_width,
+                                           // COLOR_DIM]
+    const S *__restrict__ ray_color_weights, // [COLOR_DIM]
     // grad outputs
     const S *__restrict__ v_render_colors, // [C, image_height, image_width,
                                            // COLOR_DIM]
@@ -57,6 +60,9 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     tile_offsets += camera_id * tile_height * tile_width;
     render_alphas += camera_id * image_height * image_width;
     last_ids += camera_id * image_height * image_width;
+    if (render_colors != nullptr) {
+        render_colors += camera_id * image_height * image_width * COLOR_DIM;
+    }
     v_render_colors += camera_id * image_height * image_width * COLOR_DIM;
     v_render_alphas += camera_id * image_height * image_width;
     if (backgrounds != nullptr) {
@@ -197,7 +203,14 @@ __global__ void rasterize_to_pixels_bwd_kernel(
                 const S fac = alpha * T;
                 GSPLAT_PRAGMA_UNROLL
                 for (uint32_t k = 0; k < COLOR_DIM; ++k) {
-                    v_rgb_local[k] = fac * v_render_c[k];
+                    S grad_factor = v_render_c[k];
+                    if (ray_color_weights != nullptr) {
+                        grad_factor +=
+                            ray_color_weights[k] *
+                            (rgbs_batch[t * COLOR_DIM + k] -
+                             render_colors[pix_id * COLOR_DIM + k]);
+                    }
+                    v_rgb_local[k] = fac * grad_factor;
                 }
                 // contribution from this pixel
                 S v_alpha = 0.f;
@@ -301,11 +314,13 @@ call_kernel_with_dim(
     // forward outputs
     const torch::Tensor &render_alphas, // [C, image_height, image_width, 1]
     const torch::Tensor &last_ids,      // [C, image_height, image_width]
+    const at::optional<torch::Tensor> &render_colors, // [C, H, W, D]
     // gradients of outputs
     const torch::Tensor &v_render_colors, // [C, image_height, image_width, 3]
     const torch::Tensor &v_render_alphas, // [C, image_height, image_width, 1]
     // options
-    bool absgrad
+    bool absgrad,
+    const at::optional<torch::Tensor> &ray_color_weights // [D]
 ) {
 
     GSPLAT_DEVICE_GUARD(means2d);
@@ -319,6 +334,16 @@ call_kernel_with_dim(
     GSPLAT_CHECK_INPUT(last_ids);
     GSPLAT_CHECK_INPUT(v_render_colors);
     GSPLAT_CHECK_INPUT(v_render_alphas);
+    if (render_colors.has_value()) {
+        GSPLAT_CHECK_INPUT(render_colors.value());
+    }
+    if (ray_color_weights.has_value()) {
+        GSPLAT_CHECK_INPUT(ray_color_weights.value());
+        TORCH_CHECK(
+            render_colors.has_value(),
+            "render_colors is required when ray_color_weights is provided"
+        );
+    }
     if (backgrounds.has_value()) {
         GSPLAT_CHECK_INPUT(backgrounds.value());
     }
@@ -389,6 +414,12 @@ call_kernel_with_dim(
                 flatten_ids.data_ptr<int32_t>(),
                 render_alphas.data_ptr<float>(),
                 last_ids.data_ptr<int32_t>(),
+                render_colors.has_value()
+                    ? render_colors.value().data_ptr<float>()
+                    : nullptr,
+                ray_color_weights.has_value()
+                    ? ray_color_weights.value().data_ptr<float>()
+                    : nullptr,
                 v_render_colors.data_ptr<float>(),
                 v_render_alphas.data_ptr<float>(),
                 absgrad ? reinterpret_cast<vec2<float> *>(
@@ -431,11 +462,13 @@ rasterize_to_pixels_bwd_tensor(
     // forward outputs
     const torch::Tensor &render_alphas, // [C, image_height, image_width, 1]
     const torch::Tensor &last_ids,      // [C, image_height, image_width]
+    const at::optional<torch::Tensor> &render_colors, // [C, H, W, D]
     // gradients of outputs
     const torch::Tensor &v_render_colors, // [C, image_height, image_width, 3]
     const torch::Tensor &v_render_alphas, // [C, image_height, image_width, 1]
     // options
-    bool absgrad
+    bool absgrad,
+    const at::optional<torch::Tensor> &ray_color_weights // [D]
 ) {
 
     GSPLAT_CHECK_INPUT(colors);
@@ -457,9 +490,11 @@ rasterize_to_pixels_bwd_tensor(
             flatten_ids,                                                       \
             render_alphas,                                                     \
             last_ids,                                                          \
+            render_colors,                                                     \
             v_render_colors,                                                   \
             v_render_alphas,                                                   \
-            absgrad                                                            \
+            absgrad,                                                           \
+            ray_color_weights                                                  \
         );
 
     switch (COLOR_DIM) {

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -215,11 +215,13 @@ rasterize_to_pixels_bwd_tensor(
     // forward outputs
     const torch::Tensor &render_alphas, // [C, image_height, image_width, 1]
     const torch::Tensor &last_ids,      // [C, image_height, image_width]
+    const at::optional<torch::Tensor> &render_colors, // [C, H, W, D]
     // gradients of outputs
     const torch::Tensor &v_render_colors, // [C, image_height, image_width, 3]
     const torch::Tensor &v_render_alphas, // [C, image_height, image_width, 1]
     // options
-    bool absgrad
+    bool absgrad,
+    const at::optional<torch::Tensor> &ray_color_weights // [D]
 );
 
 std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(

--- a/gsplat/cuda/include/bindings.h
+++ b/gsplat/cuda/include/bindings.h
@@ -433,7 +433,8 @@ rasterize_to_pixels_bwd_2dgs_tensor(
     const torch::Tensor &v_render_distort, // [C, image_height, image_width, 1]
     const torch::Tensor &v_render_median,  // [C, image_height, image_width, 1]
     // options
-    bool absgrad
+    bool absgrad,
+    const at::optional<torch::Tensor> &ray_color_weights // [COLOR_DIM]
 );
 
 std::tuple<torch::Tensor, torch::Tensor>

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -1091,6 +1091,7 @@ def rasterization_2dgs(
     distloss: bool = False,
     depth_mode: Literal["expected", "median"] = "expected",
     normals_coordinate: Literal["world", "camera"] = "world",
+    ray_color_weights: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Dict]:
     """Rasterize a set of 2D Gaussians (N) to a batch of image planes (C).
 
@@ -1102,6 +1103,14 @@ def rasterization_2dgs(
         `ray_transforms` VJPs. With `packed=False`, camera gradients include the
         CUDA-accumulated `ray_transforms` VJP and the direct normal-to-viewmat
         rotation term.
+
+    .. note::
+        **Ray-Color Consistency**: `ray_color_weights` injects a detached,
+        per-channel L2 surrogate gradient into the rasterized color/features only.
+        Targets are raw composited channels before Python postprocessing such as
+        expected-depth normalization. Separate normal, distortion, and median-depth
+        outputs are unaffected. Dynamic loss scaling must also be applied to the
+        weights.
 
     Args:
         means: The 3D centers of the Gaussians. [N, 3]
@@ -1154,6 +1163,9 @@ def rasterization_2dgs(
         distloss: If true, use distortion regularization to get better geometry detail.
         depth_mode: render depth mode. Choose from expected depth and median depth.
         normals_coordinate: the coordinate system of the normals.
+        ray_color_weights: Optional per-channel weights for backward-only ray-color
+            consistency. The shape must match the rasterized color channel count after
+            adding any requested depth channel. Default: None.
 
     Returns:
         A tuple:
@@ -1335,6 +1347,18 @@ def rasterization_2dgs(
         pass
     if backgrounds is not None:
         assert backgrounds.shape == (C, colors.shape[-1]), backgrounds.shape
+    if ray_color_weights is not None:
+        if ray_color_weights.shape != (colors.shape[-1],):
+            raise ValueError(
+                "ray_color_weights must have shape "
+                f"({colors.shape[-1]},), got {tuple(ray_color_weights.shape)}"
+            )
+        if ray_color_weights.device != colors.device:
+            raise ValueError("ray_color_weights must be on the same device as colors")
+        if ray_color_weights.dtype != colors.dtype:
+            raise ValueError("ray_color_weights must have the same dtype as colors")
+        if ray_color_weights.requires_grad:
+            raise ValueError("ray_color_weights must not require gradients")
 
     (
         render_colors,
@@ -1358,6 +1382,7 @@ def rasterization_2dgs(
         packed=packed,
         absgrad=absgrad,
         distloss=distloss,
+        ray_color_weights=ray_color_weights,
     )
     render_normals_from_depth = None
     if render_mode in ["ED", "RGB+ED"]:

--- a/gsplat/rendering.py
+++ b/gsplat/rendering.py
@@ -55,6 +55,7 @@ def rasterization(
     distributed: bool = False,
     camera_model: Literal["pinhole", "ortho", "fisheye"] = "pinhole",
     covars: Optional[Tensor] = None,
+    ray_color_weights: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Dict]:
     """Rasterize a set of 3D Gaussians (N) to a batch of image planes (C).
 
@@ -136,6 +137,15 @@ def rasterization(
         `AbsGS: Recovering Fine Details for 3D Gaussian Splatting <https://arxiv.org/abs/2404.10484>`_,
         which is shown to be more effective for splitting Gaussians during training.
 
+    .. note::
+        **Ray-Color Consistency**: `ray_color_weights` injects the gradient of an
+        implicit, detached per-channel L2 surrogate during the rasterizer backward
+        pass. Targets are the raw composited rasterizer channels before Python
+        postprocessing such as expected-depth normalization. It does not return a
+        scalar loss. Because this gradient is independent of the rendered image's
+        upstream gradient, callers using dynamic loss scaling must apply the same
+        scale to `ray_color_weights` before calling this function.
+
     .. warning::
         Gradients with respect to camera intrinsics `Ks` are partial. They match
         the projection helper behavior for packed and unpacked modes, but only
@@ -200,6 +210,11 @@ def rasterization(
             and "fisheye". Default is "pinhole".
         covars: Optional covariance matrices of the Gaussians. If provided, the `quats` and
             `scales` will be ignored. [N, 3, 3], Default is None.
+        ray_color_weights: Optional per-channel weights for backward-only ray-color
+            consistency. Its shape must match the final rendered channel count, including
+            depth channels requested by `render_mode`. The target is the detached raw
+            composited rasterizer value, including the background and before Python
+            postprocessing such as expected-depth normalization. Default: None.
 
     Returns:
         A tuple:
@@ -510,6 +525,19 @@ def rasterization(
     else:  # RGB
         pass
 
+    if ray_color_weights is not None:
+        if ray_color_weights.shape != (colors.shape[-1],):
+            raise ValueError(
+                "ray_color_weights must have shape "
+                f"({colors.shape[-1]},), got {tuple(ray_color_weights.shape)}"
+            )
+        if ray_color_weights.device != colors.device:
+            raise ValueError("ray_color_weights must be on the same device as colors")
+        if ray_color_weights.dtype != colors.dtype:
+            raise ValueError("ray_color_weights must have the same dtype as colors")
+        if ray_color_weights.requires_grad:
+            raise ValueError("ray_color_weights must not require gradients")
+
     # Identify intersecting tiles
     tile_width = math.ceil(width / float(tile_size))
     tile_height = math.ceil(height / float(tile_size))
@@ -556,6 +584,11 @@ def rasterization(
         render_colors, render_alphas = [], []
         for i in range(n_chunks):
             colors_chunk = colors[..., i * channel_chunk : (i + 1) * channel_chunk]
+            ray_color_weights_chunk = (
+                ray_color_weights[i * channel_chunk : (i + 1) * channel_chunk]
+                if ray_color_weights is not None
+                else None
+            )
             backgrounds_chunk = (
                 backgrounds[..., i * channel_chunk : (i + 1) * channel_chunk]
                 if backgrounds is not None
@@ -574,6 +607,7 @@ def rasterization(
                 backgrounds=backgrounds_chunk,
                 packed=packed,
                 absgrad=absgrad,
+                ray_color_weights=ray_color_weights_chunk,
             )
             render_colors.append(render_colors_)
             render_alphas.append(render_alphas_)
@@ -593,6 +627,7 @@ def rasterization(
             backgrounds=backgrounds,
             packed=packed,
             absgrad=absgrad,
+            ray_color_weights=ray_color_weights,
         )
     if render_mode in ["ED", "RGB+ED"]:
         # normalize the accumulated depth to get the expected depth

--- a/tests/test_ray_color_weights.py
+++ b/tests/test_ray_color_weights.py
@@ -167,9 +167,7 @@ def test_ray_color_weights_use_raw_depth_before_expected_depth_normalization():
     device = torch.device("cuda:0")
     gradients = []
     for render_mode in ["RGB+D", "RGB+ED"]:
-        means = torch.tensor(
-            [[0.0, 0.0, 2.0]], device=device, requires_grad=True
-        )
+        means = torch.tensor([[0.0, 0.0, 2.0]], device=device, requires_grad=True)
         rendered, _, _ = rasterization(
             means=means,
             quats=torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device),
@@ -183,6 +181,179 @@ def test_ray_color_weights_use_raw_depth_before_expected_depth_normalization():
             ),
             width=16,
             height=16,
+            render_mode=render_mode,
+            ray_color_weights=torch.tensor([0.0, 0.0, 0.0, 0.5], device=device),
+        )
+        (rendered.sum() * 0.0).backward()
+        gradients.append(means.grad.detach().clone())
+
+    assert gradients[0].abs().sum() > 0
+    torch.testing.assert_close(gradients[1], gradients[0])
+
+
+def _make_2dgs_ray_transforms(shape, device):
+    transform = torch.tensor(
+        [[-0.01, 0.0, 0.0], [0.0, -0.01, 0.0], [0.0, 0.0, 1.0]],
+        device=device,
+    )
+    return transform.expand(*shape, 3, 3).clone()
+
+
+def test_ray_color_weights_2dgs_add_detached_per_channel_gradient():
+    from gsplat.cuda._wrapper import rasterize_to_pixels_2dgs
+
+    device = torch.device("cuda:0")
+    means2d = torch.tensor(
+        [[[8.0, 8.0], [8.0, 8.0]]], device=device, requires_grad=True
+    )
+    ray_transforms = _make_2dgs_ray_transforms((1, 2), device).requires_grad_()
+    colors = torch.tensor(
+        [[[0.2, 0.6, 0.9], [0.8, 0.1, 0.4]]],
+        device=device,
+        requires_grad=True,
+    )
+    opacities = torch.tensor([[0.4, 0.3]], device=device, requires_grad=True)
+    normals = torch.zeros((1, 2, 3), device=device, requires_grad=True)
+    densify = torch.zeros((1, 2, 2), device=device, requires_grad=True)
+    background = torch.tensor([[0.1, 0.3, 0.7]], device=device)
+    channel_weights = torch.tensor([0.25, 0.0, 0.5], device=device)
+
+    rendered, _, rendered_normals, distort, median = rasterize_to_pixels_2dgs(
+        means2d,
+        ray_transforms,
+        colors,
+        opacities,
+        normals,
+        densify,
+        16,
+        16,
+        16,
+        torch.zeros((1, 1, 1), dtype=torch.int32, device=device),
+        torch.tensor([0, 1], dtype=torch.int32, device=device),
+        backgrounds=background,
+        ray_color_weights=channel_weights,
+    )
+    zero_loss = (
+        rendered.sum() + rendered_normals.sum() + distort.sum() + median.sum()
+    ) * 0.0
+    zero_loss.backward()
+
+    ys, xs = torch.meshgrid(
+        torch.arange(16, device=device, dtype=torch.float32) + 0.5,
+        torch.arange(16, device=device, dtype=torch.float32) + 0.5,
+        indexing="ij",
+    )
+    visibility = torch.exp(-((8.0 - xs).square() + (8.0 - ys).square()))
+    alpha1 = torch.where(0.4 * visibility >= 1.0 / 255.0, 0.4 * visibility, 0.0)
+    alpha2 = torch.where(0.3 * visibility >= 1.0 / 255.0, 0.3 * visibility, 0.0)
+    weight1 = alpha1
+    weight2 = (1.0 - alpha1) * alpha2
+    final = (
+        weight1[..., None] * colors.detach()[0, 0]
+        + weight2[..., None] * colors.detach()[0, 1]
+        + ((1.0 - alpha1) * (1.0 - alpha2))[..., None] * background[0]
+    )
+    expected1 = (
+        weight1[..., None] * channel_weights * (colors.detach()[0, 0] - final)
+    ).sum(dim=(0, 1))
+    expected2 = (
+        weight2[..., None] * channel_weights * (colors.detach()[0, 1] - final)
+    ).sum(dim=(0, 1))
+
+    torch.testing.assert_close(colors.grad[0, 0], expected1, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(colors.grad[0, 1], expected2, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(opacities.grad, torch.zeros_like(opacities.grad))
+    torch.testing.assert_close(means2d.grad, torch.zeros_like(means2d.grad))
+    torch.testing.assert_close(
+        ray_transforms.grad, torch.zeros_like(ray_transforms.grad)
+    )
+    torch.testing.assert_close(normals.grad, torch.zeros_like(normals.grad))
+    torch.testing.assert_close(densify.grad, torch.zeros_like(densify.grad))
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_ray_color_weights_2dgs_keep_cameras_separate(packed: bool):
+    from gsplat.cuda._wrapper import rasterize_to_pixels_2dgs
+
+    device = torch.device("cuda:0")
+    means2d = torch.tensor([[8.0, 8.0], [8.0, 8.0]], device=device)
+    ray_transforms = _make_2dgs_ray_transforms((2,), device)
+    colors = torch.tensor(
+        [[0.2, 0.6, 0.9], [0.8, 0.1, 0.4]], device=device, requires_grad=True
+    )
+    opacities = torch.tensor([0.4, 0.3], device=device)
+    normals = torch.zeros((2, 3), device=device)
+    densify = torch.zeros((2, 2), device=device)
+    if not packed:
+        means2d = means2d[:, None]
+        ray_transforms = ray_transforms[:, None]
+        colors = colors.detach()[:, None].requires_grad_()
+        opacities = opacities[:, None]
+        normals = normals[:, None]
+        densify = densify[:, None]
+
+    backgrounds = torch.tensor([[0.1, 0.3, 0.7], [0.9, 0.2, 0.0]], device=device)
+    channel_weights = torch.tensor([0.25, 0.0, 0.5], device=device)
+    rendered, _, _, _, _ = rasterize_to_pixels_2dgs(
+        means2d,
+        ray_transforms,
+        colors,
+        opacities,
+        normals,
+        densify,
+        16,
+        16,
+        16,
+        torch.tensor([[[0]], [[1]]], dtype=torch.int32, device=device),
+        torch.tensor([0, 1], dtype=torch.int32, device=device),
+        backgrounds=backgrounds,
+        packed=packed,
+        ray_color_weights=channel_weights,
+    )
+    (rendered.sum() * 0.0).backward()
+
+    color_values = colors.detach() if packed else colors.detach()[:, 0]
+    ys, xs = torch.meshgrid(
+        torch.arange(16, device=device, dtype=torch.float32) + 0.5,
+        torch.arange(16, device=device, dtype=torch.float32) + 0.5,
+        indexing="ij",
+    )
+    visibility = torch.exp(-((8.0 - xs).square() + (8.0 - ys).square()))
+    for camera_id in range(2):
+        alpha = opacities.reshape(-1)[camera_id] * visibility
+        alpha = torch.where(alpha >= 1.0 / 255.0, alpha, 0.0)
+        final = (
+            alpha[..., None] * color_values[camera_id]
+            + (1.0 - alpha[..., None]) * backgrounds[camera_id]
+        )
+        expected = (
+            alpha[..., None] * channel_weights * (color_values[camera_id] - final)
+        ).sum(dim=(0, 1))
+        actual = colors.grad[camera_id] if packed else colors.grad[camera_id, 0]
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_ray_color_weights_2dgs_use_raw_depth_before_expected_normalization():
+    from gsplat.rendering import rasterization_2dgs
+
+    device = torch.device("cuda:0")
+    gradients = []
+    for render_mode in ["RGB+D", "RGB+ED"]:
+        means = torch.tensor([[0.0, 0.0, 2.0]], device=device, requires_grad=True)
+        rendered, *_ = rasterization_2dgs(
+            means=means,
+            quats=torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device),
+            scales=torch.full((1, 3), 0.5, device=device),
+            opacities=torch.full((1,), 0.5, device=device),
+            colors=torch.ones((1, 3), device=device),
+            viewmats=torch.eye(4, device=device)[None],
+            Ks=torch.tensor(
+                [[[16.0, 0.0, 8.0], [0.0, 16.0, 8.0], [0.0, 0.0, 1.0]]],
+                device=device,
+            ),
+            width=16,
+            height=16,
+            backgrounds=torch.zeros((1, 3), device=device),
             render_mode=render_mode,
             ray_color_weights=torch.tensor([0.0, 0.0, 0.0, 0.5], device=device),
         )

--- a/tests/test_ray_color_weights.py
+++ b/tests/test_ray_color_weights.py
@@ -1,0 +1,193 @@
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+
+
+def test_ray_color_weights_add_detached_per_channel_gradient():
+    from gsplat.cuda._wrapper import rasterize_to_pixels
+
+    device = torch.device("cuda:0")
+    image_width = image_height = tile_size = 16
+    means2d = torch.tensor(
+        [[[8.0, 8.0], [8.0, 8.0]]], device=device, requires_grad=True
+    )
+    conics = torch.tensor(
+        [[[0.1, 0.0, 0.1], [0.1, 0.0, 0.1]]],
+        device=device,
+        requires_grad=True,
+    )
+    colors = torch.tensor(
+        [[[0.2, 0.6, 0.9], [0.8, 0.1, 0.4]]],
+        device=device,
+        requires_grad=True,
+    )
+    opacities = torch.tensor([[0.4, 0.3]], device=device, requires_grad=True)
+    background = torch.tensor([[0.1, 0.3, 0.7]], device=device)
+    isect_offsets = torch.zeros((1, 1, 1), dtype=torch.int32, device=device)
+    flatten_ids = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    channel_weights = torch.tensor([0.25, 0.0, 0.5], device=device)
+
+    rendered, _ = rasterize_to_pixels(
+        means2d,
+        conics,
+        colors,
+        opacities,
+        image_width,
+        image_height,
+        tile_size,
+        isect_offsets,
+        flatten_ids,
+        backgrounds=background,
+        ray_color_weights=channel_weights,
+    )
+    (rendered.sum() * 0.0).backward()
+
+    ys, xs = torch.meshgrid(
+        torch.arange(image_height, device=device, dtype=torch.float32) + 0.5,
+        torch.arange(image_width, device=device, dtype=torch.float32) + 0.5,
+        indexing="ij",
+    )
+    sigma = 0.05 * ((8.0 - xs).square() + (8.0 - ys).square())
+    alpha1 = 0.4 * torch.exp(-sigma)
+    alpha2 = 0.3 * torch.exp(-sigma)
+    alpha1 = torch.where(alpha1 >= 1.0 / 255.0, alpha1, 0.0)
+    alpha2 = torch.where(alpha2 >= 1.0 / 255.0, alpha2, 0.0)
+    weight1 = alpha1
+    weight2 = (1.0 - alpha1) * alpha2
+    final_transmittance = (1.0 - alpha1) * (1.0 - alpha2)
+    final_color = (
+        weight1[..., None] * colors.detach()[0, 0]
+        + weight2[..., None] * colors.detach()[0, 1]
+        + final_transmittance[..., None] * background[0]
+    )
+    expected1 = (
+        weight1[..., None] * channel_weights * (colors.detach()[0, 0] - final_color)
+    ).sum(dim=(0, 1))
+    expected2 = (
+        weight2[..., None] * channel_weights * (colors.detach()[0, 1] - final_color)
+    ).sum(dim=(0, 1))
+
+    torch.testing.assert_close(colors.grad[0, 0], expected1, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(colors.grad[0, 1], expected2, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(opacities.grad, torch.zeros_like(opacities.grad))
+    torch.testing.assert_close(means2d.grad, torch.zeros_like(means2d.grad))
+    torch.testing.assert_close(conics.grad, torch.zeros_like(conics.grad))
+
+
+def test_ray_color_weights_none_matches_default():
+    from gsplat.cuda._wrapper import rasterize_to_pixels
+
+    device = torch.device("cuda:0")
+    inputs = {
+        "means2d": torch.tensor([[[8.0, 8.0]]], device=device),
+        "conics": torch.tensor([[[0.1, 0.0, 0.1]]], device=device),
+        "colors": torch.tensor([[[0.2, 0.6, 0.9]]], device=device),
+        "opacities": torch.tensor([[0.5]], device=device),
+        "image_width": 16,
+        "image_height": 16,
+        "tile_size": 16,
+        "isect_offsets": torch.zeros((1, 1, 1), dtype=torch.int32, device=device),
+        "flatten_ids": torch.zeros((1,), dtype=torch.int32, device=device),
+    }
+
+    default_colors = inputs["colors"].clone().requires_grad_()
+    default_render, _ = rasterize_to_pixels(**{**inputs, "colors": default_colors})
+    default_render.sum().backward()
+
+    none_colors = inputs["colors"].clone().requires_grad_()
+    none_render, _ = rasterize_to_pixels(
+        **{**inputs, "colors": none_colors}, ray_color_weights=None
+    )
+    none_render.sum().backward()
+
+    torch.testing.assert_close(none_render, default_render)
+    torch.testing.assert_close(none_colors.grad, default_colors.grad)
+
+
+@pytest.mark.parametrize("packed", [False, True])
+def test_ray_color_weights_keep_cameras_separate(packed: bool):
+    from gsplat.cuda._wrapper import rasterize_to_pixels
+
+    device = torch.device("cuda:0")
+    means2d = torch.tensor([[8.0, 8.0], [8.0, 8.0]], device=device)
+    conics = torch.tensor([[0.1, 0.0, 0.1], [0.1, 0.0, 0.1]], device=device)
+    colors = torch.tensor(
+        [[0.2, 0.6, 0.9], [0.8, 0.1, 0.4]], device=device, requires_grad=True
+    )
+    opacities = torch.tensor([0.4, 0.3], device=device)
+    if not packed:
+        means2d = means2d[:, None]
+        conics = conics[:, None]
+        colors = colors.detach()[:, None].requires_grad_()
+        opacities = opacities[:, None]
+
+    backgrounds = torch.tensor([[0.1, 0.3, 0.7], [0.9, 0.2, 0.0]], device=device)
+    channel_weights = torch.tensor([0.25, 0.0, 0.5], device=device)
+    rendered, _ = rasterize_to_pixels(
+        means2d,
+        conics,
+        colors,
+        opacities,
+        16,
+        16,
+        16,
+        torch.tensor([[[0]], [[1]]], dtype=torch.int32, device=device),
+        torch.tensor([0, 1], dtype=torch.int32, device=device),
+        backgrounds=backgrounds,
+        packed=packed,
+        ray_color_weights=channel_weights,
+    )
+    (rendered.sum() * 0.0).backward()
+
+    color_values = colors.detach() if packed else colors.detach()[:, 0]
+    ys, xs = torch.meshgrid(
+        torch.arange(16, device=device, dtype=torch.float32) + 0.5,
+        torch.arange(16, device=device, dtype=torch.float32) + 0.5,
+        indexing="ij",
+    )
+    visibility = torch.exp(-0.05 * ((8.0 - xs).square() + (8.0 - ys).square()))
+    for camera_id in range(2):
+        alpha = opacities.reshape(-1)[camera_id] * visibility
+        alpha = torch.where(alpha >= 1.0 / 255.0, alpha, 0.0)
+        final = (
+            alpha[..., None] * color_values[camera_id]
+            + (1.0 - alpha[..., None]) * backgrounds[camera_id]
+        )
+        expected = (
+            alpha[..., None] * channel_weights * (color_values[camera_id] - final)
+        ).sum(dim=(0, 1))
+        actual = colors.grad[camera_id] if packed else colors.grad[camera_id, 0]
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_ray_color_weights_use_raw_depth_before_expected_depth_normalization():
+    from gsplat.rendering import rasterization
+
+    device = torch.device("cuda:0")
+    gradients = []
+    for render_mode in ["RGB+D", "RGB+ED"]:
+        means = torch.tensor(
+            [[0.0, 0.0, 2.0]], device=device, requires_grad=True
+        )
+        rendered, _, _ = rasterization(
+            means=means,
+            quats=torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device),
+            scales=torch.full((1, 3), 0.5, device=device),
+            opacities=torch.full((1,), 0.5, device=device),
+            colors=torch.ones((1, 3), device=device),
+            viewmats=torch.eye(4, device=device)[None],
+            Ks=torch.tensor(
+                [[[16.0, 0.0, 8.0], [0.0, 16.0, 8.0], [0.0, 0.0, 1.0]]],
+                device=device,
+            ),
+            width=16,
+            height=16,
+            render_mode=render_mode,
+            ray_color_weights=torch.tensor([0.0, 0.0, 0.0, 0.5], device=device),
+        )
+        (rendered.sum() * 0.0).backward()
+        gradients.append(means.grad.detach().clone())
+
+    assert gradients[0].abs().sum() > 0
+    torch.testing.assert_close(gradients[1], gradients[0])


### PR DESCRIPTION
## Summary
- add optional `ray_color_weights` to 3DGS and 2DGS rasterization APIs
- inject detached per-channel consistency gradients in the existing CUDA backward traversals
- support RGB, raw depth, and arbitrary feature channels with padding and 3DGS chunking
- preserve default behavior when weights are `None`
- fix the 2DGS backward `render_colors` camera offset required for batched targets and distortion

## CUDA gradient
```cpp
grad_factor += ray_color_weights[k] *
    (gaussian_color[k] - final_composited_color[k]);
grad_color += alpha * transmittance * grad_factor;
```

The target is the raw composited rasterizer channel, including background and before Python postprocessing such as expected-depth normalization. The term is added only to evaluated feature gradients, not directly to alpha, opacity, transmittance, or geometry/blending gradients. Normal downstream dependencies remain active, including SH view direction and selected depth channels.

Separate 2DGS normal, distortion, and median-depth outputs are not selected by `ray_color_weights`.

## Tests
- `PYTHONPATH=$PWD pytest tests/test_ray_color_weights.py -q` (9 passed)
- `PYTHONPATH=$PWD pytest tests/test_2dgs.py -q -W ignore::pytest.PytestRemovedIn9Warning` (17 passed)
- `PYTHONPATH=$PWD pytest tests/test_rasterization.py -q` (24 passed)
- broader suite previously reached 96 passes with 15 unrelated existing failures involving projection references, missing fisheye reference parameters, and missing optional PLAS

## Notes
Dynamic loss scaling must also be applied to `ray_color_weights`, because this backward-only gradient is independent of the rendered image upstream gradient.